### PR TITLE
Fix linux build_examples script to explicitly use bash.

### DIFF
--- a/tests/linux/build_examples
+++ b/tests/linux/build_examples
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 ROOT=$(cd "$(dirname "$0")/../.."; pwd)
 TESTS_DIR="$ROOT/tests/linux"


### PR DESCRIPTION
Because, the script actually depends on it.
    
Here's what happens on Ubuntu (dash):
    
```
tests/linux/build_examples: 36: tests/linux/build_examples: [[: not found
```