### PR TITLE
Fix segfault when application is derived from JUCEApplicationBase

### DIFF
--- a/modules/tracktion_engine/model/edit/tracktion_EditUtilities.cpp
+++ b/modules/tracktion_engine/model/edit/tracktion_EditUtilities.cpp
@@ -335,6 +335,16 @@ void deleteRegionOfTracks (Edit& edit, EditTimeRange rangeToDelete, bool onlySel
         {
             t->deleteRegion (rangeToDelete, selectionManager);
 
+            // Remove any tiny clips that might be left over
+            Array<Clip*> clipsToRemove;
+
+            for (auto& c : t->getClips())
+                if (c->getPosition().getLength() < 0.0001)
+                    clipsToRemove.add (c);
+
+            for (auto c : clipsToRemove)
+                c->removeFromParentTrack();
+
             if (closeGap)
             {
                 for (auto& c : t->getClips())

--- a/modules/tracktion_engine/utilities/tracktion_BackgroundJobs.h
+++ b/modules/tracktion_engine/utilities/tracktion_BackgroundJobs.h
@@ -173,7 +173,7 @@ private:
 
     void updateJobs()
     {
-        if (juce::JUCEApplication::getInstance()->isInitialising())
+        if (juce::JUCEApplicationBase::getInstance()->isInitialising())
             return;
 
         float newTotal = 0.0f;


### PR DESCRIPTION
The `updateJobs` method of the `tracktion_engine::BackgroundJobs` class segfaults if the application class derived from JUCEApplicationBase and not JUCEApplication.

The `JUCEApplication::getInstance()` is not virtual. However, it does just delegates to `JUCEApplicationBase::getInstance`.  See Juce's [`JUCEAapplication::getInstance()`](https://github.com/WeAreROLI/JUCE/blob/06c3674e510f991d88f881203aedd85a60fbced9/modules/juce_gui_basics/application/juce_Application.cpp#L34-L37)

This one line fix should allow any application derived from `JUCEApplicationBase` to use the BackgroundJobs class. 

See also: [forum.juce.com thread](https://forum.juce.com/t/segfault-when-application-is-derived-from-juceapplicationbase-and-not-juceapplication/37567?u=audioishi)