### PR TITLE
Doxygen: Fix make doc batch command.

### DIFF
--- a/doxygen/make.bat
+++ b/doxygen/make.bat
@@ -1,2 +1,2 @@
-python process_source_files.py ..\modules build
+python process_source_files.py --subdirs tracktion_graph,tracktion_engine ..\modules build
 doxygen

--- a/examples/common/Utilities.h
+++ b/examples/common/Utilities.h
@@ -60,7 +60,7 @@ namespace PlayHeadHelpers
         if (numerator == 0 || denominator == 0)
             return "1|1|000";
 
-        auto quarterNotesPerBar = (numerator * 4 / denominator);
+        auto quarterNotesPerBar = ((double)numerator * 4.0 / (double)denominator);
         auto beats  = (fmod (quarterNotes, quarterNotesPerBar) / quarterNotesPerBar) * numerator;
 
         auto bar    = ((int) quarterNotes) / quarterNotesPerBar + 1;


### PR DESCRIPTION
If don't set the value of the subdirs option, the pre-processing by python doesn't seem to work properly.