### PR TITLE
examples: Preventing some variables from becoming a NaN.

### DIFF
--- a/examples/common/Utilities.h
+++ b/examples/common/Utilities.h
@@ -60,7 +60,7 @@ namespace PlayHeadHelpers
         if (numerator == 0 || denominator == 0)
             return "1|1|000";
 
-        auto quarterNotesPerBar = (numerator * 4 / denominator);
+        auto quarterNotesPerBar = ((double)numerator * 4.0 / (double)denominator);
         auto beats  = (fmod (quarterNotes, quarterNotesPerBar) / quarterNotesPerBar) * numerator;
 
         auto bar    = ((int) quarterNotes) / quarterNotesPerBar + 1;


### PR DESCRIPTION
For example, if the DAW's beat setting is 4/32nds, the quarterNotesPerBar variable will be 0, and the beats variable will be assigned as NaN. It causing a crash of VST host application.