### PR TITLE
Doxygen: Fix make doc batch command for Windows.

### DIFF
--- a/doxygen/make.bat
+++ b/doxygen/make.bat
@@ -1,2 +1,2 @@
-python process_source_files.py ..\modules build
+python process_source_files.py --subdirs tracktion_graph,tracktion_engine ..\modules build
 doxygen


### PR DESCRIPTION
If don't set the value of the subdirs option, the pre-processing by python doesn't seem to work properly.