### PR TITLE
Fixed compilation when enabling AirWindows with MSVC.

### DIFF
--- a/modules/tracktion_engine/tracktion_engine_airwindows.cpp
+++ b/modules/tracktion_engine/tracktion_engine_airwindows.cpp
@@ -9,6 +9,9 @@
 
 #if ! JUCE_PROJUCER_LIVE_BUILD
 
+#undef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES 1
+
 #include <atomic>
 #include <numeric>
 #include <set>
@@ -50,7 +53,7 @@ using namespace juce;
 
 #if JUCE_WINDOWS
  #pragma warning (push)
- #pragma warning (disable : 4244 4100 4305 4065 4701 4706 4723)
+ #pragma warning (disable : 4244 4100 4305 4065 4701 4706 4723 4458)
 #endif
 
 namespace tracktion_engine


### PR DESCRIPTION
`M_PI` support needs to be explicitly enabled for MSVC (or so it seems!).