### PR TITLE
Replace TRACKTION_ASSERT_MESSAGE_THREAD with the JUCE rendition.

### DIFF
--- a/modules/tracktion_engine/audio_files/tracktion_AudioFile.cpp
+++ b/modules/tracktion_engine/audio_files/tracktion_AudioFile.cpp
@@ -470,14 +470,14 @@ SmartThumbnail::SmartThumbnail (Engine& e, const AudioFile& f, juce::Component& 
                           e.getAudioFileManager().getAudioThumbnailCache()),
       file (f), engine (e), edit (ed), component (componentToRepaint)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     startTimer (initialTimerDelay);
     engine.getAudioFileManager().activeThumbnails.add (this);
 }
 
 SmartThumbnail::~SmartThumbnail()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     engine.getAudioFileManager().activeThumbnails.removeAllInstancesOf (this);
     clear();
@@ -485,7 +485,7 @@ SmartThumbnail::~SmartThumbnail()
 
 bool SmartThumbnail::areThumbnailsFullyLoaded (Engine& engine)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     for (auto thumb : engine.getAudioFileManager().activeThumbnails)
         if (! thumb->isFullyLoaded())
@@ -667,7 +667,7 @@ bool AudioFileManager::checkFileTime (KnownFile& f)
 void AudioFileManager::checkFileForChanges (const AudioFile& file)
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     bool changed = false;
 
@@ -687,7 +687,7 @@ void AudioFileManager::checkFileForChanges (const AudioFile& file)
 
 void AudioFileManager::checkFilesForChanges()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     juce::Array<AudioFile> changedFiles;
 
@@ -731,7 +731,7 @@ void AudioFileManager::releaseFile (const AudioFile& file)
 void AudioFileManager::callListeners (const AudioFile& file)
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     thumbnailCache->removeThumb (file.getHash());
 
@@ -745,7 +745,7 @@ void AudioFileManager::callListeners (const AudioFile& file)
 void AudioFileManager::forceFileUpdate (const AudioFile& file)
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     // this doesn't check for file time and is used when files are changed rapidly such as when recording
     const juce::ScopedLock sl (knownFilesLock);

--- a/modules/tracktion_engine/audio_files/tracktion_RecordingThumbnailManager.h
+++ b/modules/tracktion_engine/audio_files/tracktion_RecordingThumbnailManager.h
@@ -26,7 +26,7 @@ public:
 
         ~Thumbnail()
         {
-            TRACKTION_ASSERT_MESSAGE_THREAD
+            JUCE_ASSERT_MESSAGE_THREAD
             engine.getRecordingThumbnailManager().thumbs.removeAllInstancesOf (this);
         }
 
@@ -52,7 +52,7 @@ public:
                      engine.getAudioFileManager().getAudioThumbnailCache()),
                 file (f), hash (f.hashCode64())
         {
-            TRACKTION_ASSERT_MESSAGE_THREAD
+            JUCE_ASSERT_MESSAGE_THREAD
             engine.getRecordingThumbnailManager().thumbs.addIfNotAlreadyThere (this);
         }
 
@@ -62,7 +62,7 @@ public:
     //==============================================================================
     Thumbnail::Ptr getThumbnailFor (const juce::File& f)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         for (auto* t : thumbs)
             if (t->file == f)

--- a/modules/tracktion_engine/midi/tracktion_MidiList.h
+++ b/modules/tracktion_engine/midi/tracktion_MidiList.h
@@ -229,7 +229,7 @@ private:
 
         const juce::Array<EventType*>& getSortedList()
         {
-            TRACKTION_ASSERT_MESSAGE_THREAD
+            JUCE_ASSERT_MESSAGE_THREAD
 
             const juce::ScopedLock sl (lock);
 

--- a/modules/tracktion_engine/model/automation/modifiers/tracktion_MIDITrackerModifier.cpp
+++ b/modules/tracktion_engine/model/automation/modifiers/tracktion_MIDITrackerModifier.cpp
@@ -185,7 +185,7 @@ void MIDITrackerModifier::refreshCurrentValue()
 void MIDITrackerModifier::updateMapFromTree()
 {
     if (! edit.isLoading())
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
     Map newMap;
 

--- a/modules/tracktion_engine/model/automation/tracktion_AutomatableParameter.cpp
+++ b/modules/tracktion_engine/model/automation/tracktion_AutomatableParameter.cpp
@@ -167,7 +167,7 @@ public:
     {
         jassert (! parameter.getEdit().isLoading());
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         std::unique_ptr<AutomationIterator> newStream;
 
@@ -200,7 +200,7 @@ public:
 
     float getValueAt (double time) override
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         return curve.getValueAt (time);
     }
 
@@ -282,7 +282,7 @@ struct MacroSource : public AutomationModifierSource
 
     float getValueAt (double time) override
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         auto macroValue = macro->getCurve().getValueAt (time);
         return AutomationScaleHelpers::mapValue (macroValue, assignment->offset, assignment->value, assignment->curve);
     }
@@ -357,7 +357,7 @@ struct AutomatableParameter::AutomationSourceList  : private ValueTreeObjectList
 
     juce::ReferenceCountedObjectPtr<AutomationModifierSource> getSourceFor (ModifierAssignment& ass)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         for (auto o : objects)
             if (o->assignment.get() == &ass)
@@ -368,7 +368,7 @@ struct AutomatableParameter::AutomationSourceList  : private ValueTreeObjectList
 
     juce::ReferenceCountedObjectPtr<AutomationModifierSource> getSourceFor (ModifierSource& mod)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         for (auto o : objects)
             if (o->assignment->isForModifierSource (mod))
@@ -700,7 +700,7 @@ AutomatableParameter::ModifierAssignment::Ptr AutomatableParameter::addModifier 
 
 void AutomatableParameter::removeModifier (ModifierAssignment& assignment)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (auto existing = getAutomationSourceList().getSourceFor (assignment))
         existing->state.getParent().removeChild (existing->state, &getEdit().getUndoManager());
@@ -710,7 +710,7 @@ void AutomatableParameter::removeModifier (ModifierAssignment& assignment)
 
 void AutomatableParameter::removeModifier (ModifierSource& source)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (auto existing = getAutomationSourceList().getSourceFor (source))
         existing->state.getParent().removeChild (existing->state, &getEdit().getUndoManager());
@@ -720,7 +720,7 @@ void AutomatableParameter::removeModifier (ModifierSource& source)
 
 juce::ReferenceCountedArray<AutomatableParameter::ModifierAssignment> AutomatableParameter::getAssignments() const
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     juce::ReferenceCountedArray<ModifierAssignment> assignments;
 
     getAutomationSourceList()
@@ -1072,7 +1072,7 @@ AutomatableParameter::AutomationSourceList& AutomatableParameter::getAutomationS
 
 void AutomatableParameter::updateToFollowCurve (double time)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     float newModifierValue = 0.0f;
 
     getAutomationSourceList()

--- a/modules/tracktion_engine/model/automation/tracktion_AutomatableParameter.h
+++ b/modules/tracktion_engine/model/automation/tracktion_AutomatableParameter.h
@@ -294,7 +294,7 @@ juce::Array<AutomatableParameter*> getAllAutomatableParameter (Edit&);
 template<typename AssignmentType, typename ModifierSourceType>
 juce::ReferenceCountedArray<AssignmentType> getAssignmentsForSource (Edit& edit, const ModifierSourceType& source)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     juce::ReferenceCountedArray<AssignmentType> assignments;
 
     for (auto* ap : getAllAutomatableParameter (edit))

--- a/modules/tracktion_engine/model/automation/tracktion_AutomationCurve.cpp
+++ b/modules/tracktion_engine/model/automation/tracktion_AutomationCurve.cpp
@@ -128,7 +128,7 @@ double AutomationCurve::getLength() const
 //==============================================================================
 float AutomationCurve::getValueAt (double time) const
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     auto index = nextIndexAfter (time);
 
     if (index <= 0)

--- a/modules/tracktion_engine/model/automation/tracktion_AutomationRecordManager.cpp
+++ b/modules/tracktion_engine/model/automation/tracktion_AutomationRecordManager.cpp
@@ -236,7 +236,7 @@ void AutomationRecordManager::toggleWriteAutomationMode()
 
 void AutomationRecordManager::postFirstAutomationChange (AutomatableParameter& param, float originalValue)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     auto entry = std::make_unique<AutomationParamData> (param, originalValue);
 
     // recording status has changed, so inform our listeners
@@ -248,7 +248,7 @@ void AutomationRecordManager::postFirstAutomationChange (AutomatableParameter& p
 
 void AutomationRecordManager::postAutomationChange (AutomatableParameter& param, double time, float value)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     const ScopedLock sl (lock);
 
     for (auto p : recordedParams)

--- a/modules/tracktion_engine/model/automation/tracktion_MacroParameter.cpp
+++ b/modules/tracktion_engine/model/automation/tracktion_MacroParameter.cpp
@@ -56,7 +56,7 @@ void MacroParameter::parameterChanged (float, bool byAutomation)
     if (byAutomation)
         return;
 
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     auto cursorPos = edit.getTransport().getCurrentPosition();
 
     for (auto ap : getAllParametersBeingModifiedBy (edit, *this))
@@ -160,12 +160,12 @@ MacroParameterList::MacroParameterList (Edit& e, const ValueTree& v)
 
 MacroParameterList::~MacroParameterList()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 }
 
 MacroParameter* MacroParameterList::createMacroParameter()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     auto* um = &edit.getUndoManager();
 
     ValueTree v (IDs::MACROPARAMETER);
@@ -183,7 +183,7 @@ MacroParameter* MacroParameterList::createMacroParameter()
 
 void MacroParameterList::removeMacroParameter (MacroParameter& mp)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     jassert (list != nullptr);
     auto* um = &edit.getUndoManager();
 
@@ -208,7 +208,7 @@ void MacroParameterList::hideMacroParametersFromTracks() const
 {
     if (! edit.isLoading())
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
     }
 
     for (auto mp : getMacroParameters())
@@ -227,7 +227,7 @@ ReferenceCountedArray<MacroParameter> MacroParameterList::getMacroParameters() c
 
 Track* MacroParameterList::getTrack() const
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     for (auto p (state.getParent()); p.isValid(); p = p.getParent())
         if (TrackList::isTrack (p))

--- a/modules/tracktion_engine/model/automation/tracktion_Modifier.cpp
+++ b/modules/tracktion_engine/model/automation/tracktion_Modifier.cpp
@@ -56,7 +56,7 @@ void Modifier::remove()
 //==============================================================================
 void Modifier::baseClassInitialise (const PlaybackInitialisationInfo& info)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     if (initialiseCount++ == 0)
     {
         CRASH_TRACER
@@ -69,7 +69,7 @@ void Modifier::baseClassInitialise (const PlaybackInitialisationInfo& info)
 
 void Modifier::baseClassDeinitialise()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     jassert (initialiseCount > 0);
 
     if (--initialiseCount == 0)
@@ -110,7 +110,7 @@ bool ModifierList::isModifier (const juce::Identifier& i)
 ReferenceCountedArray<Modifier> ModifierList::getModifiers() const
 {
     if (! edit.isLoading())
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
     ReferenceCountedArray<Modifier> mods;
 
@@ -123,7 +123,7 @@ ReferenceCountedArray<Modifier> ModifierList::getModifiers() const
 //==============================================================================
 ReferenceCountedObjectPtr<Modifier> ModifierList::insertModifier (ValueTree v, int index, SelectionManager* sm)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     jassert (isSuitableType (v));
     auto um = &edit.getUndoManager();
 

--- a/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.cpp
@@ -1776,7 +1776,7 @@ void AudioClipBase::sendMirrorUpdateToAllPlugins (Plugin& p) const
 //==============================================================================
 bool AudioClipBase::setupARA (Edit& ed, bool dontPopupErrorMessages)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     static bool araReentrancyCheck = false;
 
     if (araReentrancyCheck)
@@ -1961,7 +1961,7 @@ void AudioClipBase::updateSourceFile()
     if (! isInitialised)
         return;
 
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     // check to see if our source file already exists, it may have been created by another clip
     // if it does exist, we will just use that, otherwise we need to start our own render operation
@@ -1986,7 +1986,7 @@ void AudioClipBase::updateSourceFile()
 
 void AudioClipBase::renderSource()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     jassert (isInitialised);
 
     const AudioFile audioFile (edit.engine, getCurrentSourceFile());
@@ -2029,7 +2029,7 @@ void AudioClipBase::renderSource()
 
 void AudioClipBase::renderComplete()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     // Updates the thumbnail message
     changed();
 
@@ -2511,7 +2511,7 @@ void AudioClipBase::beginRenderingNewProxyIfNeeded()
 //==============================================================================
 void AudioClipBase::jobFinished (RenderManager::Job& job, bool completedOk)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (&job == renderJob.get())
     {

--- a/modules/tracktion_engine/model/clips/tracktion_Clip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_Clip.cpp
@@ -494,7 +494,7 @@ void Clip::valueTreeParentChanged (juce::ValueTree& v)
 
 void Clip::updateParentTrack()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     auto parent = state.getParent();
 
     if (TrackList::isTrack (parent))

--- a/modules/tracktion_engine/model/clips/tracktion_EditClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_EditClip.cpp
@@ -100,7 +100,7 @@ bool EditClip::needsRender() const
 
 RenderManager::Job::Ptr EditClip::getRenderJob (const AudioFile& destFile)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     // do this here so we don't end up creating a new instance of our Edit
     if (auto existing = edit.engine.getRenderManager().getRenderJobWithoutCreating (destFile))
@@ -125,7 +125,7 @@ void EditClip::renderComplete()
 
 String EditClip::getRenderMessage()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (renderJob == nullptr || getCurrentSourceFile().existsAsFile())
         return {};
@@ -236,7 +236,7 @@ void EditClip::valueTreePropertyChanged (ValueTree& v, const juce::Identifier& i
 {
     if (v == state && i == IDs::renderEnabled)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         renderEnabled.forceUpdateOfCachedValue();
 
         setUsesProxy (renderEnabled);

--- a/modules/tracktion_engine/model/clips/tracktion_MidiClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_MidiClip.cpp
@@ -275,7 +275,7 @@ MidiList& MidiClip::getSequence() const noexcept
 MidiList& MidiClip::getSequenceLooped()
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (! isLooping())
         return getSequence();

--- a/modules/tracktion_engine/model/clips/tracktion_WarpTimeManager.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_WarpTimeManager.cpp
@@ -156,7 +156,7 @@ private:
           numChannels (af.getNumChannels()),
           reader (e.getAudioFileManager().cache.createReader (af))
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         // N.B. The argumnet to the Job constructor is the proxy file to use
         // Don't send the audio file here or it will get deleted!
         jassert (proxy.isNull());

--- a/modules/tracktion_engine/model/clips/tracktion_WaveAudioClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_WaveAudioClip.cpp
@@ -524,7 +524,7 @@ WaveCompManager& WaveAudioClip::getCompManager()
 //==============================================================================
 RenderManager::Job::Ptr WaveAudioClip::getRenderJob (const AudioFile& destFile)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     // do this here so we don't end up creating a multiple copies of a File
     if (auto existing = edit.engine.getRenderManager().getRenderJobWithoutCreating (destFile))
@@ -556,7 +556,7 @@ RenderManager::Job::Ptr WaveAudioClip::getRenderJob (const AudioFile& destFile)
 
 String WaveAudioClip::getRenderMessage()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (renderJob == nullptr || getAudioFile().isValid())
         return {};

--- a/modules/tracktion_engine/model/edit/tracktion_Edit.cpp
+++ b/modules/tracktion_engine/model/edit/tracktion_Edit.cpp
@@ -389,7 +389,7 @@ struct Edit::TreeWatcher   : public juce::ValueTree::Listener
     {
         if (! edit.isLoading())
         {
-            TRACKTION_ASSERT_MESSAGE_THREAD
+            JUCE_ASSERT_MESSAGE_THREAD
         }
     }
 
@@ -413,7 +413,7 @@ struct Edit::ChangedPluginsList
     /** Flushes the plugin state to the Edit if it has changed. */
     void flushPluginStateIfNeeded (Plugin& p)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         const int index = plugins.indexOf (&p);
 
         if (index != -1)
@@ -640,7 +640,7 @@ void Edit::setProjectItemID (ProjectItemID newID)
 Edit::ScopedRenderStatus::ScopedRenderStatus (Edit& ed, bool shouldReallocateOnDestruction)
     : edit (ed), reallocateOnDestruction (shouldReallocateOnDestruction)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     jassert (edit.performingRenderCount >= 0);
     ++edit.performingRenderCount;
     edit.getTransport().freePlaybackContext();
@@ -648,7 +648,7 @@ Edit::ScopedRenderStatus::ScopedRenderStatus (Edit& ed, bool shouldReallocateOnD
 
 Edit::ScopedRenderStatus::~ScopedRenderStatus()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     jassert (edit.performingRenderCount > 0);
     --edit.performingRenderCount;
 
@@ -1488,7 +1488,7 @@ void Edit::toggleTimecodeMode()
 //==============================================================================
 void Edit::sendTempoOrPitchSequenceChangedUpdates()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     // notify clips of tempo changes
     for (auto t : getClipTracks (*this))
@@ -2915,7 +2915,7 @@ std::unique_ptr<Edit> Edit::createSingleTrackEdit (Engine& engine)
 
 //==============================================================================
 EditDeleter::EditDeleter() = default;
-EditDeleter::~EditDeleter() { TRACKTION_ASSERT_MESSAGE_THREAD }
+EditDeleter::~EditDeleter() { JUCE_ASSERT_MESSAGE_THREAD }
 
 void EditDeleter::deleteEdit (std::unique_ptr<Edit> ed)
 {

--- a/modules/tracktion_engine/model/edit/tracktion_EditFileOperations.cpp
+++ b/modules/tracktion_engine/model/edit/tracktion_EditFileOperations.cpp
@@ -25,7 +25,7 @@ struct ThreadedEditFileWriter   : private Thread
 
     void writeTreeToFile (ValueTree&& v, const File& f)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         pending.add (std::pair<ValueTree, File> (v, f));
         waiter.signal();
         startThread();
@@ -33,7 +33,7 @@ struct ThreadedEditFileWriter   : private Thread
 
     void flushAllFiles()
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         waiter.signal();
         startThread();
 

--- a/modules/tracktion_engine/model/export/tracktion_Renderer.cpp
+++ b/modules/tracktion_engine/model/export/tracktion_Renderer.cpp
@@ -148,7 +148,7 @@ struct Renderer::RenderTask::RendererContext
           sourceToUpdate (sourceToUpdate_)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         jassert (r.engine != nullptr);
         jassert (r.edit != nullptr);
         jassert (r.time.getLength() > 0.0);

--- a/modules/tracktion_engine/model/tracks/tracktion_AudioTrack.cpp
+++ b/modules/tracktion_engine/model/tracks/tracktion_AudioTrack.cpp
@@ -842,7 +842,7 @@ void AudioTrack::valueTreePropertyChanged (ValueTree& v, const juce::Identifier&
     }
     else if (Clip::isClipState (v))
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD;
+        JUCE_ASSERT_MESSAGE_THREAD;
 
         if (i == IDs::start || i == IDs::length)
             asyncCaller.updateAsync (updateAutoCrossfadesFlag);

--- a/modules/tracktion_engine/model/tracks/tracktion_ClipTrack.cpp
+++ b/modules/tracktion_engine/model/tracks/tracktion_ClipTrack.cpp
@@ -332,7 +332,7 @@ void ClipTrack::flushStateToValueTree()
 //==============================================================================
 void ClipTrack::refreshTrackItems() const
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (trackItemsDirty)
     {

--- a/modules/tracktion_engine/playback/devices/tracktion_InputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_InputDevice.cpp
@@ -351,7 +351,7 @@ bool InputDeviceInstance::isLivePlayEnabled (const Track& t) const
 void InputDeviceInstance::prepareAndPunchRecord()
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (auto t = getTargetTracks().getFirst())
     {

--- a/modules/tracktion_engine/playback/devices/tracktion_MidiInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_MidiInputDevice.cpp
@@ -626,7 +626,7 @@ public:
 
     bool isRecording() override
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         return recording;
     }
 

--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -426,7 +426,7 @@ public:
 
     bool isRecording() override
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         return recordingContext != nullptr;
     }
 
@@ -513,7 +513,7 @@ public:
                                           bool discardRecordings,
                                           SelectionManager* selectionManager) override
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         CRASH_TRACER
         
         Clip::Array clips;

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
@@ -248,7 +248,7 @@ String DeviceManager::getDefaultMidiInDeviceName (bool translated)
 void DeviceManager::closeDevices()
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     jassert (activeContexts.isEmpty());
     clearAllContextDevices();
@@ -283,7 +283,7 @@ DeviceManager::ContextDeviceListRebuilder::~ContextDeviceListRebuilder()
 void DeviceManager::initialiseMidi()
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     ContextDeviceListRebuilder deviceRebuilder (*this);
 
     midiInputs.clear();
@@ -467,7 +467,7 @@ void DeviceManager::resetToDefaults (bool resetInputDevices, bool resetOutputDev
 Result DeviceManager::createVirtualMidiDevice (const String& name)
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     {
         StringArray virtualDevices;
@@ -498,7 +498,7 @@ Result DeviceManager::createVirtualMidiDevice (const String& name)
 void DeviceManager::deleteVirtualMidiDevice (VirtualMidiInputDevice* vmi)
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     ContextDeviceListRebuilder deviceRebuilder (*this);
 
     engine.getPropertyStorage().removePropertyItem (SettingID::virtualmidiin, vmi->getName());
@@ -544,7 +544,7 @@ bool DeviceManager::waveDeviceListNeedsRebuilding()
 void DeviceManager::rebuildWaveDeviceList()
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     static bool reentrant = false;
     jassert (! reentrant);
@@ -965,7 +965,7 @@ int DeviceManager::getNumMidiInDevices() const
 
 MidiInputDevice* DeviceManager::getMidiInDevice (int index) const
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     return midiInputs[index];
 }
 
@@ -1208,7 +1208,7 @@ void DeviceManager::updateNumCPUs()
 
 void DeviceManager::addContext (EditPlaybackContext* c)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     double lastStreamTime;
 

--- a/modules/tracktion_engine/playback/tracktion_EditPlaybackContext.cpp
+++ b/modules/tracktion_engine/playback/tracktion_EditPlaybackContext.cpp
@@ -58,7 +58,7 @@ EditPlaybackContext::~EditPlaybackContext()
 
 void EditPlaybackContext::releaseDeviceList()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
 
     const ScopedValueSetter<bool> alocateSetter (isAllocated, isAllocated);
@@ -74,7 +74,7 @@ void EditPlaybackContext::releaseDeviceList()
 
 void EditPlaybackContext::rebuildDeviceList()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
 
     jassert (waveInputs.isEmpty() && midiInputs.isEmpty()
@@ -545,7 +545,7 @@ static SelectionManager* findAppropriateSelectionManager (Edit& ed)
 
 Clip::Array EditPlaybackContext::stopRecording (InputDeviceInstance& in, EditTimeRange recordedRange, bool discardRecordings)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
 
     const auto loopRange = transport.getLoopRange();
@@ -559,7 +559,7 @@ Clip::Array EditPlaybackContext::stopRecording (InputDeviceInstance& in, EditTim
 
 Clip::Array EditPlaybackContext::recordingFinished (EditTimeRange recordedRange, bool discardRecordings)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
     Clip::Array clips;
 
@@ -571,7 +571,7 @@ Clip::Array EditPlaybackContext::recordingFinished (EditTimeRange recordedRange,
 
 Result EditPlaybackContext::applyRetrospectiveRecord (Array<Clip*>* clips)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
 
     bool inputAssigned = false;
@@ -699,7 +699,7 @@ void EditPlaybackContext::fillNextAudioBlock (EditTimeRange streamTime, float** 
 
 InputDeviceInstance* EditPlaybackContext::getInputFor (InputDevice* d) const
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     for (auto i : waveInputs)
         if (&i->owner == d)

--- a/modules/tracktion_engine/playback/tracktion_LevelMeasurer.cpp
+++ b/modules/tracktion_engine/playback/tracktion_LevelMeasurer.cpp
@@ -49,7 +49,7 @@ LevelMeasurer::LevelMeasurer()
 
 LevelMeasurer::~LevelMeasurer()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 }
 
 //==============================================================================

--- a/modules/tracktion_engine/playback/tracktion_TransportControl.cpp
+++ b/modules/tracktion_engine/playback/tracktion_TransportControl.cpp
@@ -644,14 +644,14 @@ struct TransportControl::ScreenSaverDefeater
 {
     ScreenSaverDefeater()
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         ++numScreenSaverDefeaters;
         Desktop::setScreenSaverEnabled (numScreenSaverDefeaters == 0);
     }
 
     ~ScreenSaverDefeater()
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         --numScreenSaverDefeaters;
         jassert (numScreenSaverDefeaters >= 0);
         Desktop::setScreenSaverEnabled (numScreenSaverDefeaters == 0);

--- a/modules/tracktion_engine/plugins/ARA/tracktion_ARAWrapperInterfaces.h
+++ b/modules/tracktion_engine/plugins/ARA/tracktion_ARAWrapperInterfaces.h
@@ -67,7 +67,7 @@ public:
 
     void beginEditing (bool dontCheckMusicalContext)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (canEdit (dontCheckMusicalContext))
             dci->beginEditing (dcRef);
@@ -75,7 +75,7 @@ public:
 
     void endEditing (bool dontCheckMusicalContext)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (canEdit (dontCheckMusicalContext))
             dci->endEditing (dcRef);
@@ -84,7 +84,7 @@ public:
     void flushStateToValueTree (ValueTree& v)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         MemoryBlock data;
         MemoryOutputStream out (data, false);
@@ -104,7 +104,7 @@ public:
     void beginRestoringState (const juce::ValueTree& state)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         jassert (state.hasType (IDs::ARADOCUMENT));
 
@@ -126,7 +126,7 @@ public:
     void endRestoringState()
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (lastArchiveState != nullptr)
             dci->endRestoringDocumentFromArchive (dcRef, toHostRef (lastArchiveState.get()));
@@ -186,7 +186,7 @@ struct ARADocumentCreatorCallback : private MessageThreadCallback
     void performAction() override
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         result.reset (createDocumentInternal (edit));
     }
@@ -206,7 +206,7 @@ static ARADocument* createDocument (Edit& edit)
 static ARADocument* createDocumentInternal (Edit& edit)
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     ReferenceCountedObjectPtr<ExternalPlugin> plugin (MelodyneInstanceFactory::getInstance (edit.engine).createPlugin (edit));
 
@@ -313,7 +313,7 @@ public:
     MusicalContextWrapper (ARADocument& doc)  : document (doc)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (document.dci != nullptr)
         {
@@ -327,7 +327,7 @@ public:
     ~MusicalContextWrapper()
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (document.dci != nullptr && musicalContextRef != nullptr)
             document.dci->destroyMusicalContext (document.dcRef, musicalContextRef);
@@ -336,7 +336,7 @@ public:
     void update()
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (document.dci != nullptr && musicalContextRef != nullptr)
             document.dci->updateMusicalContextContent (document.dcRef, musicalContextRef,
@@ -773,7 +773,7 @@ public:
         itemID (audioClip.getAudioFile().getHashString() + "_" + audioClip.itemID.toString())
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         updateAudioSourceProperties();
         auto audioSourceProperties = getAudioSourceProperties();
@@ -782,7 +782,7 @@ public:
     ~AudioSourceWrapper()
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (audioSourceRef != nullptr)
         {
@@ -794,7 +794,7 @@ public:
     NodeReader* createReader()
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         return new NodeReader (clip.getAudioFile());
     }
 
@@ -879,7 +879,7 @@ public:
         persistentID (itemID)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         updateAudioModificationProperties();
         auto audioModificationProperties = getAudioModificationProperties();
@@ -925,7 +925,7 @@ public:
           track (track_)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         updateRegionSequenceProperties();
         auto regionSequenceProperties = getRegionSequenceProperties();
@@ -982,7 +982,7 @@ public:
         flags (factory.supportedPlaybackTransformationFlags)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         doc.willCreatePlaybackRegionOnTrack (clip.getTrack());
 
@@ -1000,7 +1000,7 @@ public:
         if (playbackRegionRef != nullptr)
         {
             CRASH_TRACER
-            TRACKTION_ASSERT_MESSAGE_THREAD
+            JUCE_ASSERT_MESSAGE_THREAD
             // TODO ARA2
             // At this point the track has already been destroyed, so this
             // function won't work properly. What to do?

--- a/modules/tracktion_engine/plugins/ARA/tracktion_MelodyneFileReader.cpp
+++ b/modules/tracktion_engine/plugins/ARA/tracktion_MelodyneFileReader.cpp
@@ -76,7 +76,7 @@ struct ARAClipPlayer  : private SelectableListener
         file (c.getAudioFile()),
         edit (ed)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         jassert (file.getFile().existsAsFile());
         edit.tempoSequence.addSelectableListener (this);
     }
@@ -84,7 +84,7 @@ struct ARAClipPlayer  : private SelectableListener
     ~ARAClipPlayer()
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         edit.tempoSequence.removeSelectableListener (this);
 
@@ -124,7 +124,7 @@ struct ARAClipPlayer  : private SelectableListener
     //==============================================================================
     bool initialise (ARAClipPlayer* clipToClone)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         CRASH_TRACER
 
         if (auto doc = getDocument())
@@ -174,7 +174,7 @@ struct ARAClipPlayer  : private SelectableListener
     void updateContent (ARAClipPlayer* clipToClone)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (MessageManager::getInstance()->isThisTheMessageThread()
             && getEdit().getTransport().isAllowedToReallocate())
@@ -247,8 +247,8 @@ struct ARAClipPlayer  : private SelectableListener
     }
 
     //==============================================================================
-    void startProcessing()  { TRACKTION_ASSERT_MESSAGE_THREAD if (playbackRegionAndSource != nullptr) playbackRegionAndSource->enable(); }
-    void stopProcessing()   { TRACKTION_ASSERT_MESSAGE_THREAD if (playbackRegionAndSource != nullptr) playbackRegionAndSource->disable(); }
+    void startProcessing()  { JUCE_ASSERT_MESSAGE_THREAD if (playbackRegionAndSource != nullptr) playbackRegionAndSource->enable(); }
+    void stopProcessing()   { JUCE_ASSERT_MESSAGE_THREAD if (playbackRegionAndSource != nullptr) playbackRegionAndSource->disable(); }
 
     class ContentAnalyser
     {
@@ -391,7 +391,7 @@ private:
     void recreateTrack (ARAClipPlayer* clipToClone)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         jassert (melodyneInstance != nullptr);
         jassert (melodyneInstance->factory != nullptr);
@@ -414,7 +414,7 @@ private:
     void internalUpdateContent (ARAClipPlayer* clipToClone)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (auto doc = getDocument())
         {
@@ -501,7 +501,7 @@ private:
 //==============================================================================
 MelodyneFileReader::MelodyneFileReader (Edit& ed, AudioClipBase& clip)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
 
     player.reset (new ARAClipPlayer (ed, *this, clip));
@@ -512,7 +512,7 @@ MelodyneFileReader::MelodyneFileReader (Edit& ed, AudioClipBase& clip)
 
 MelodyneFileReader::MelodyneFileReader (Edit& ed, AudioClipBase& clip, MelodyneFileReader& other)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
 
     if (other.player != nullptr)
@@ -528,7 +528,7 @@ MelodyneFileReader::MelodyneFileReader (Edit& ed, AudioClipBase& clip, MelodyneF
 
 MelodyneFileReader::~MelodyneFileReader()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
 
     if (player != nullptr)
@@ -847,7 +847,7 @@ struct ARADocumentHolder::Pimpl
 
     void initialise()
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         araDocument.reset (ARAClipPlayer::createDocument (edit));
 
         if (araDocument != nullptr)
@@ -879,7 +879,7 @@ ARADocumentHolder::ARADocumentHolder (Edit& e, const juce::ValueTree& v)
 
 ARADocumentHolder::~ARADocumentHolder()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
     pimpl = nullptr;
 }
@@ -898,7 +898,7 @@ ARADocumentHolder::Pimpl* ARADocumentHolder::getPimpl()
 
 void ARADocumentHolder::flushStateToValueTree()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (pimpl != nullptr)
         if (pimpl->araDocument != nullptr)

--- a/modules/tracktion_engine/plugins/ARA/tracktion_MelodyneInstanceFactory.h
+++ b/modules/tracktion_engine/plugins/ARA/tracktion_MelodyneInstanceFactory.h
@@ -51,7 +51,7 @@ public:
 
     MelodyneInstance* createInstance (ExternalPlugin& p, ARADocumentControllerRef dcRef)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         jassert (plugin != nullptr);
 
         std::unique_ptr<MelodyneInstance> w (new MelodyneInstance());
@@ -76,7 +76,7 @@ private:
 
     MelodyneInstanceFactory (Engine& engine)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         CRASH_TRACER
 
         plugin = createMelodynePlugin (engine);
@@ -146,7 +146,7 @@ private:
 
     bool setExtensionInstance (MelodyneInstance& w, ARADocumentControllerRef dcRef)
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         CRASH_TRACER
 
         if (dcRef == nullptr)
@@ -245,7 +245,7 @@ static std::unique_ptr<AudioPluginInstance> createMelodynePlugin (Engine& engine
 static std::unique_ptr<AudioPluginInstance> createMelodynePlugin (Engine& engine)
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     auto araDescs = engine.getPluginManager().getARACompatiblePlugDescriptions();
 

--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
@@ -770,7 +770,7 @@ void ExternalPlugin::doFullInitialisation()
 //==============================================================================
 ExternalPlugin::~ExternalPlugin()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER_PLUGIN (getDebugName());
     notifyListenersOfDeletion();
     windowState->hideWindowForShutdown();
@@ -813,7 +813,7 @@ void ExternalPlugin::flushPluginStateToValueTree()
 		if (pluginInstance->getNumPrograms() > 0)
 			state.setProperty (IDs::programNum,  pluginInstance->getCurrentProgram(), um);
 
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         MemoryBlock chunk;
 
         pluginInstance->suspendProcessing (true);
@@ -897,7 +897,7 @@ void ExternalPlugin::getPluginStateFromTree (MemoryBlock& mb)
 
 void ExternalPlugin::updateFromMirroredPluginIfNeeded (Plugin& changedPlugin)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (changedPlugin.itemID == masterPluginID)
     {

--- a/modules/tracktion_engine/plugins/internal/tracktion_InsertPlugin.cpp
+++ b/modules/tracktion_engine/plugins/internal/tracktion_InsertPlugin.cpp
@@ -323,7 +323,7 @@ void InsertPlugin::restorePluginStateFromValueTree (const juce::ValueTree& v)
 void InsertPlugin::updateDeviceTypes()
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     StringArray devices, aliases;
     BigInteger hasAudio, hasMidi;

--- a/modules/tracktion_engine/plugins/internal/tracktion_RackType.cpp
+++ b/modules/tracktion_engine/plugins/internal/tracktion_RackType.cpp
@@ -98,7 +98,7 @@ struct RackType::PluginRenderingInfo
                      const OwnedArray<PluginRenderingInfo>& renderContexts)
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         if (! initialised)
         {
@@ -412,14 +412,14 @@ struct RackType::ConnectionList  : public ValueTreeObjectList<RackConnection>
     RackConnection* createNewObject (const juce::ValueTree& v) override
     {
         if (! type.edit.isLoading())
-            TRACKTION_ASSERT_MESSAGE_THREAD
+            JUCE_ASSERT_MESSAGE_THREAD
 
         return new RackConnection (v, type.getUndoManager());
     }
 
     void deleteObject (RackConnection* t) override
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         jassert (t != nullptr);
         delete t;
     }
@@ -1112,7 +1112,7 @@ void RackType::addConnection (EditItemID srcId, int sourcePin,
 void RackType::removeConnection (EditItemID srcId, int sourcePin,
                                  EditItemID dstId, int destPin)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     for (int i = connectionList->objects.size(); --i >= 0;)
     {
@@ -1131,7 +1131,7 @@ void RackType::removeConnection (EditItemID srcId, int sourcePin,
 void RackType::checkConnections()
 {
     if (! edit.isLoading())
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
     for (int i = connectionList->objects.size(); --i >= 0;)
     {
@@ -1428,7 +1428,7 @@ int RackType::addOutput (int index, const String& name)
 
 void RackType::removeInput (int index)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     int toRemove = findIndexOfNthInstanceOf (state, IDs::INPUT, index);
 
     if (toRemove >= 0)
@@ -1444,7 +1444,7 @@ void RackType::removeInput (int index)
 
 void RackType::removeOutput (int index)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     int toRemove = findIndexOfNthInstanceOf (state, IDs::OUTPUT, index);
 
     if (toRemove >= 0)
@@ -1488,7 +1488,7 @@ UndoManager* RackType::getUndoManager() const
 void RackType::countInstancesInEdit()
 {
     CRASH_TRACER
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     numberOfInstancesInEdit = 0;
 
@@ -1725,7 +1725,7 @@ private:
 
 double RackType::getLatencySeconds (double rate, int bufferSize)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (latencyCalculation)
         if (latencyCalculation->sampleRate != rate || latencyCalculation->bufferSize != bufferSize)
@@ -1740,7 +1740,7 @@ double RackType::getLatencySeconds (double rate, int bufferSize)
 //==============================================================================
 void RackType::updateTempBuferSizes()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     CRASH_TRACER
     const ScopedLock sl (renderLock);
 
@@ -2328,7 +2328,7 @@ void RackType::triggerUpdate()
 void RackType::updateRenderContext()
 {
     if (edit.isLoading())
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 }
 
 //==============================================================================

--- a/modules/tracktion_engine/plugins/tracktion_PluginWindowState.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginWindowState.cpp
@@ -25,21 +25,21 @@ void PluginWindowState::deleteWindow()
 
 void PluginWindowState::incRefCount()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     ++windowShowerCount;
     startTimer (100);
 }
 
 void PluginWindowState::decRefCount()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     --windowShowerCount;
     startTimer (100);
 }
 
 void PluginWindowState::showWindowExplicitly()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     wasExplicitlyClosed = false;
     stopTimer();
     showWindow();
@@ -47,7 +47,7 @@ void PluginWindowState::showWindowExplicitly()
 
 void PluginWindowState::closeWindowExplicitly()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
 
     if (pluginWindow && pluginWindow->isVisible())
     {

--- a/modules/tracktion_engine/selection/tracktion_SelectionManager.cpp
+++ b/modules/tracktion_engine/selection/tracktion_SelectionManager.cpp
@@ -121,7 +121,7 @@ bool Selectable::isSelectableValid (const Selectable* s) noexcept
 
 void Selectable::addSelectableListener (SelectableListener* l)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     jassert (l != nullptr);
     jassert (! isCallingListeners);
     jassert (! hasNotifiedListenersOfDeletion);
@@ -130,14 +130,14 @@ void Selectable::addSelectableListener (SelectableListener* l)
 
 void Selectable::removeSelectableListener (SelectableListener* l)
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     jassert (! isCallingListeners);
     selectableListeners.remove (l);
 }
 
 void Selectable::sendChangeCallbackToListenersIfNeeded()
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
+    JUCE_ASSERT_MESSAGE_THREAD
     needsAnUpdate = false;
 
     const ScopedValueSetter<bool> svs (isCallingListeners, true);

--- a/modules/tracktion_engine/tracktion_engine.h
+++ b/modules/tracktion_engine/tracktion_engine.h
@@ -177,10 +177,6 @@
 #endif
 
 //==============================================================================
-#define TRACKTION_ASSERT_MESSAGE_THREAD \
-    jassert (juce::MessageManager::getInstance()->currentThreadHasLockedMessageManager());
-
-//==============================================================================
 namespace tracktion_engine
 {
     class Engine;

--- a/modules/tracktion_engine/utilities/tracktion_AsyncFunctionUtils.h
+++ b/modules/tracktion_engine/utilities/tracktion_AsyncFunctionUtils.h
@@ -180,7 +180,7 @@ private:
     void handleAsyncUpdate() override
     {
         CRASH_TRACER
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
 
         performAction();
         finished.set (1);

--- a/modules/tracktion_engine/utilities/tracktion_ValueTreeUtilities.h
+++ b/modules/tracktion_engine/utilities/tracktion_ValueTreeUtilities.h
@@ -241,7 +241,7 @@ struct SortedValueTreeObjectList    : protected ValueTreeObjectList<ObjectType>
     /** Returns the object for a given state. */
     const juce::Array<ObjectType*>& getSortedObjects() const
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         jassert (! insidePropertyChangedMethod);
 
         if (setIfDifferent (needsSorting, false))
@@ -285,7 +285,7 @@ private:
 
     void triggerSort() const
     {
-        TRACKTION_ASSERT_MESSAGE_THREAD
+        JUCE_ASSERT_MESSAGE_THREAD
         needsSorting = true;
     }
 


### PR DESCRIPTION
See https://github.com/Tracktion/tracktion_engine/issues/34

This is simply a find/replace. JUCE's macro now offers a pointer check for the singleton instance as well.