### PR TITLE
Cmake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,77 @@ tracktion*.deb
 examples/projects
 bin
 doxygen/doc
+
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion,
+# Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,5 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+builds/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/../../../../../../:\code\repos\personal\tracktion_engine\.idea/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/compilerexplorer.settings.xml
+++ b/.idea/compilerexplorer.settings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerExplorerSettingsProvider">
+    <option name="enabled" value="false" />
+    <option name="initialNoticeShown" value="true" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/tracktion_engine.iml" filepath="$PROJECT_DIR$/.idea/tracktion_engine.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/tracktion_engine.iml
+++ b/.idea/tracktion_engine.iml
@@ -1,8 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="CPP_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/.idea/tracktion_engine.iml
+++ b/.idea/tracktion_engine.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/modules/juce" vcs="Git" />
+  </component>
+</project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_guard()
 
-cmake_minimum_required(3.17...3.20)
+cmake_minimum_required(3.15...3.20)
 
 project(
         tracktion_engine
@@ -11,7 +11,7 @@ project(
         HOMEPAGE_URL "https://github.com/Tracktion/tracktion_engine"
 )
 
-add_subdirectory(${PROJECT_SOURCE_DIR}/modules)
+add_subdirectory(modules)
 
 if (JUCE_BUILD_EXAMPLES)
     add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+include_guard()
+
+cmake_minimum_required(3.17...3.20)
+
+project(
+        tracktion_engine
+        VERSION 1.0.0
+        DESCRIPTION
+        "High level data model and set of classes for building
+        sequence based audio applications."
+        HOMEPAGE_URL "https://github.com/Tracktion/tracktion_engine"
+)
+
+add_subdirectory(${PROJECT_SOURCE_DIR}/modules)
+
+if (JUCE_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 include_guard()
 
-cmake_minimum_required(3.15...3.20)
+cmake_minimum_required(VERSION 3.15...3.20)
 
 project(
         tracktion_engine
         VERSION 1.0.0
         DESCRIPTION
-        "High level data model and set of classes for building
+        "High level data model and set of classes for building \
         sequence based audio applications."
         HOMEPAGE_URL "https://github.com/Tracktion/tracktion_engine"
 )

--- a/examples/CMake/AudioPlugin/CMakeLists.txt
+++ b/examples/CMake/AudioPlugin/CMakeLists.txt
@@ -1,0 +1,113 @@
+# Example Audio Plugin CMakeLists.txt
+
+# To get started on a new plugin, copy this entire folder (containing this file and C++ sources) to
+# a convenient location, and then start making modifications.
+
+# The first line of any CMake project should be a call to `cmake_minimum_required`, which checks
+# that the installed CMake will be able to understand the following CMakeLists, and ensures that
+# CMake's behaviour is compatible with the named version. This is a standard CMake command, so more
+# information can be found in the CMake docs.
+
+cmake_minimum_required(VERSION 3.15)
+
+# The top-level CMakeLists.txt file for a project must contain a literal, direct call to the
+# `project()` command. `project()` sets up some helpful variables that describe source/binary
+# directories, and the current project version. This is a standard CMake command.
+
+project(AUDIO_PLUGIN_EXAMPLE VERSION 0.0.1)
+
+# If you've installed JUCE somehow (via a package manager, or directly using the CMake install
+# target), you'll need to tell this project that it depends on the installed copy of JUCE. If you've
+# included JUCE directly in your source tree (perhaps as a submodule), you'll need to tell CMake to
+# include that subdirectory as part of the build.
+
+# find_package(JUCE CONFIG REQUIRED)        # If you've installed JUCE to your system
+# or
+# add_subdirectory(JUCE)                    # If you've put JUCE in a subdirectory called JUCE
+
+# If you are building a VST2 or AAX plugin, CMake needs to be told where to find these SDKs on your
+# system. This setup should be done before calling `juce_add_plugin`.
+
+# juce_set_vst2_sdk_path(...)
+# juce_set_aax_sdk_path(...)
+
+# `juce_add_plugin` adds a static library target with the name passed as the first argument
+# (AudioPluginExample here). This target is a normal CMake target, but has a lot of extra properties set
+# up by default. As well as this shared code static library, this function adds targets for each of
+# the formats specified by the FORMATS arguments. This function accepts many optional arguments.
+# Check the readme at `docs/CMake API.md` in the JUCE repo for the full list.
+
+juce_add_plugin(AudioPluginExample
+    # VERSION ...                               # Set this if the plugin version is different to the project version
+    # ICON_BIG ...                              # ICON_* arguments specify a path to an image file to use as an icon for the Standalone
+    # ICON_SMALL ...
+    # COMPANY_NAME ...                          # Specify the name of the plugin's author
+    # IS_SYNTH TRUE/FALSE                       # Is this a synth or an effect?
+    # NEEDS_MIDI_INPUT TRUE/FALSE               # Does the plugin need midi input?
+    # NEEDS_MIDI_OUTPUT TRUE/FALSE              # Does the plugin need midi output?
+    # IS_MIDI_EFFECT TRUE/FALSE                 # Is this plugin a MIDI effect?
+    # EDITOR_WANTS_KEYBOARD_FOCUS TRUE/FALSE    # Does the editor need keyboard focus?
+    # COPY_PLUGIN_AFTER_BUILD TRUE/FALSE        # Should the plugin be installed to a default location after building?
+    PLUGIN_MANUFACTURER_CODE Juce               # A four-character manufacturer id with at least one upper-case character
+    PLUGIN_CODE Dem0                            # A unique four-character plugin id with exactly one upper-case character
+                                                # GarageBand 10.3 requires the first letter to be upper-case, and the remaining letters to be lower-case
+    FORMATS AU VST3 Standalone                  # The formats to build. Other valid formats are: AAX Unity VST AU AUv3
+    PRODUCT_NAME "Audio Plugin Example")        # The name of the final executable, which can differ from the target name
+
+# `juce_generate_juce_header` will create a JuceHeader.h for a given target, which will be generated
+# into your build tree. This should be included with `#include <JuceHeader.h>`. The include path for
+# this header will be automatically added to the target. The main function of the JuceHeader is to
+# include all your JUCE module headers; if you're happy to include module headers directly, you
+# probably don't need to call this.
+
+# juce_generate_juce_header(AudioPluginExample)
+
+# `target_sources` adds source files to a target. We pass the target that needs the sources as the
+# first argument, then a visibility parameter for the sources which should normally be PRIVATE.
+# Finally, we supply a list of source files that will be built into the target. This is a standard
+# CMake command.
+
+target_sources(AudioPluginExample
+    PRIVATE
+        PluginEditor.cpp
+        PluginProcessor.cpp)
+
+# `target_compile_definitions` adds some preprocessor definitions to our target. In a Projucer
+# project, these might be passed in the 'Preprocessor Definitions' field. JUCE modules also make use
+# of compile definitions to switch certain features on/off, so if there's a particular feature you
+# need that's not on by default, check the module header for the correct flag to set here. These
+# definitions will be visible both to your code, and also the JUCE module code, so for new
+# definitions, pick unique names that are unlikely to collide! This is a standard CMake command.
+
+target_compile_definitions(AudioPluginExample
+    PUBLIC
+        # JUCE_WEB_BROWSER and JUCE_USE_CURL would be on by default, but you might not need them.
+        JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_plugin` call
+        JUCE_USE_CURL=0     # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_plugin` call
+        JUCE_VST3_CAN_REPLACE_VST2=0)
+
+# If your target needs extra binary assets, you can add them here. The first argument is the name of
+# a new static library target that will include all the binary resources. There is an optional
+# `NAMESPACE` argument that can specify the namespace of the generated binary data class. Finally,
+# the SOURCES argument should be followed by a list of source files that should be built into the
+# static library. These source files can be of any kind (wav data, images, fonts, icons etc.).
+# Conversion to binary-data will happen when your target is built.
+
+# juce_add_binary_data(AudioPluginData SOURCES ...)
+
+# `target_link_libraries` links libraries and JUCE modules to other libraries or executables. Here,
+# we're linking our executable target to the `juce::juce_audio_utils` module. Inter-module
+# dependencies are resolved automatically, so `juce_core`, `juce_events` and so on will also be
+# linked automatically. If we'd generated a binary data target above, we would need to link to it
+# here too. This is a standard CMake command.
+
+target_link_libraries(AudioPluginExample
+    PRIVATE
+        # AudioPluginData           # If we'd created a binary data target, we'd link to it here
+        juce::juce_audio_utils
+        juce::tracktion_engine
+        juce::tracktion_graph
+    PUBLIC
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_lto_flags
+        juce::juce_recommended_warning_flags)

--- a/examples/CMake/AudioPlugin/CMakeLists.txt
+++ b/examples/CMake/AudioPlugin/CMakeLists.txt
@@ -32,12 +32,12 @@ project(AUDIO_PLUGIN_EXAMPLE VERSION 0.0.1)
 # juce_set_aax_sdk_path(...)
 
 # `juce_add_plugin` adds a static library target with the name passed as the first argument
-# (AudioPluginExample here). This target is a normal CMake target, but has a lot of extra properties set
+# (TracktionAudioPluginExaple here). This target is a normal CMake target, but has a lot of extra properties set
 # up by default. As well as this shared code static library, this function adds targets for each of
 # the formats specified by the FORMATS arguments. This function accepts many optional arguments.
 # Check the readme at `docs/CMake API.md` in the JUCE repo for the full list.
 
-juce_add_plugin(AudioPluginExample
+juce_add_plugin(TracktionAudioPluginExaple
     # VERSION ...                               # Set this if the plugin version is different to the project version
     # ICON_BIG ...                              # ICON_* arguments specify a path to an image file to use as an icon for the Standalone
     # ICON_SMALL ...
@@ -60,14 +60,14 @@ juce_add_plugin(AudioPluginExample
 # include all your JUCE module headers; if you're happy to include module headers directly, you
 # probably don't need to call this.
 
-# juce_generate_juce_header(AudioPluginExample)
+# juce_generate_juce_header(TracktionAudioPluginExaple)
 
 # `target_sources` adds source files to a target. We pass the target that needs the sources as the
 # first argument, then a visibility parameter for the sources which should normally be PRIVATE.
 # Finally, we supply a list of source files that will be built into the target. This is a standard
 # CMake command.
 
-target_sources(AudioPluginExample
+target_sources(TracktionAudioPluginExaple
     PRIVATE
         PluginEditor.cpp
         PluginProcessor.cpp)
@@ -79,7 +79,7 @@ target_sources(AudioPluginExample
 # definitions will be visible both to your code, and also the JUCE module code, so for new
 # definitions, pick unique names that are unlikely to collide! This is a standard CMake command.
 
-target_compile_definitions(AudioPluginExample
+target_compile_definitions(TracktionAudioPluginExaple
     PUBLIC
         # JUCE_WEB_BROWSER and JUCE_USE_CURL would be on by default, but you might not need them.
         JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_plugin` call
@@ -101,7 +101,7 @@ target_compile_definitions(AudioPluginExample
 # linked automatically. If we'd generated a binary data target above, we would need to link to it
 # here too. This is a standard CMake command.
 
-target_link_libraries(AudioPluginExample
+target_link_libraries(TracktionAudioPluginExaple
     PRIVATE
         # AudioPluginData           # If we'd created a binary data target, we'd link to it here
         juce::juce_audio_utils

--- a/examples/CMake/AudioPlugin/PluginEditor.cpp
+++ b/examples/CMake/AudioPlugin/PluginEditor.cpp
@@ -1,0 +1,33 @@
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+//==============================================================================
+AudioPluginAudioProcessorEditor::AudioPluginAudioProcessorEditor (AudioPluginAudioProcessor& p)
+    : AudioProcessorEditor (&p), processorRef (p)
+{
+    juce::ignoreUnused (processorRef);
+    // Make sure that before the constructor has finished, you've set the
+    // editor's size to whatever you need it to be.
+    setSize (400, 300);
+}
+
+AudioPluginAudioProcessorEditor::~AudioPluginAudioProcessorEditor()
+{
+}
+
+//==============================================================================
+void AudioPluginAudioProcessorEditor::paint (juce::Graphics& g)
+{
+    // (Our component is opaque, so we must completely fill the background with a solid colour)
+    g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
+
+    g.setColour (juce::Colours::white);
+    g.setFont (15.0f);
+    g.drawFittedText ("Hello World!", getLocalBounds(), juce::Justification::centred, 1);
+}
+
+void AudioPluginAudioProcessorEditor::resized()
+{
+    // This is generally where you'll want to lay out the positions of any
+    // subcomponents in your editor..
+}

--- a/examples/CMake/AudioPlugin/PluginEditor.h
+++ b/examples/CMake/AudioPlugin/PluginEditor.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "PluginProcessor.h"
+
+//==============================================================================
+class AudioPluginAudioProcessorEditor  : public juce::AudioProcessorEditor
+{
+public:
+    explicit AudioPluginAudioProcessorEditor (AudioPluginAudioProcessor&);
+    ~AudioPluginAudioProcessorEditor() override;
+
+    //==============================================================================
+    void paint (juce::Graphics&) override;
+    void resized() override;
+
+private:
+    // This reference is provided as a quick way for your editor to
+    // access the processor object that created it.
+    AudioPluginAudioProcessor& processorRef;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioPluginAudioProcessorEditor)
+};

--- a/examples/CMake/AudioPlugin/PluginProcessor.cpp
+++ b/examples/CMake/AudioPlugin/PluginProcessor.cpp
@@ -1,0 +1,188 @@
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+//==============================================================================
+AudioPluginAudioProcessor::AudioPluginAudioProcessor()
+     : AudioProcessor (BusesProperties()
+                     #if ! JucePlugin_IsMidiEffect
+                      #if ! JucePlugin_IsSynth
+                       .withInput  ("Input",  juce::AudioChannelSet::stereo(), true)
+                      #endif
+                       .withOutput ("Output", juce::AudioChannelSet::stereo(), true)
+                     #endif
+                       )
+{
+}
+
+AudioPluginAudioProcessor::~AudioPluginAudioProcessor()
+{
+}
+
+//==============================================================================
+const juce::String AudioPluginAudioProcessor::getName() const
+{
+    return JucePlugin_Name;
+}
+
+bool AudioPluginAudioProcessor::acceptsMidi() const
+{
+   #if JucePlugin_WantsMidiInput
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+bool AudioPluginAudioProcessor::producesMidi() const
+{
+   #if JucePlugin_ProducesMidiOutput
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+bool AudioPluginAudioProcessor::isMidiEffect() const
+{
+   #if JucePlugin_IsMidiEffect
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+double AudioPluginAudioProcessor::getTailLengthSeconds() const
+{
+    return 0.0;
+}
+
+int AudioPluginAudioProcessor::getNumPrograms()
+{
+    return 1;   // NB: some hosts don't cope very well if you tell them there are 0 programs,
+                // so this should be at least 1, even if you're not really implementing programs.
+}
+
+int AudioPluginAudioProcessor::getCurrentProgram()
+{
+    return 0;
+}
+
+void AudioPluginAudioProcessor::setCurrentProgram (int index)
+{
+    juce::ignoreUnused (index);
+}
+
+const juce::String AudioPluginAudioProcessor::getProgramName (int index)
+{
+    juce::ignoreUnused (index);
+    return {};
+}
+
+void AudioPluginAudioProcessor::changeProgramName (int index, const juce::String& newName)
+{
+    juce::ignoreUnused (index, newName);
+}
+
+//==============================================================================
+void AudioPluginAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
+{
+    // Use this method as the place to do any pre-playback
+    // initialisation that you need..
+    juce::ignoreUnused (sampleRate, samplesPerBlock);
+}
+
+void AudioPluginAudioProcessor::releaseResources()
+{
+    // When playback stops, you can use this as an opportunity to free up any
+    // spare memory, etc.
+}
+
+bool AudioPluginAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
+{
+  #if JucePlugin_IsMidiEffect
+    juce::ignoreUnused (layouts);
+    return true;
+  #else
+    // This is the place where you check if the layout is supported.
+    // In this template code we only support mono or stereo.
+    // Some plugin hosts, such as certain GarageBand versions, will only
+    // load plugins that support stereo bus layouts.
+    if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono()
+     && layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
+        return false;
+
+    // This checks if the input layout matches the output layout
+   #if ! JucePlugin_IsSynth
+    if (layouts.getMainOutputChannelSet() != layouts.getMainInputChannelSet())
+        return false;
+   #endif
+
+    return true;
+  #endif
+}
+
+void AudioPluginAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer,
+                                              juce::MidiBuffer& midiMessages)
+{
+    juce::ignoreUnused (midiMessages);
+
+    juce::ScopedNoDenormals noDenormals;
+    auto totalNumInputChannels  = getTotalNumInputChannels();
+    auto totalNumOutputChannels = getTotalNumOutputChannels();
+
+    // In case we have more outputs than inputs, this code clears any output
+    // channels that didn't contain input data, (because these aren't
+    // guaranteed to be empty - they may contain garbage).
+    // This is here to avoid people getting screaming feedback
+    // when they first compile a plugin, but obviously you don't need to keep
+    // this code if your algorithm always overwrites all the output channels.
+    for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
+        buffer.clear (i, 0, buffer.getNumSamples());
+
+    // This is the place where you'd normally do the guts of your plugin's
+    // audio processing...
+    // Make sure to reset the state if your inner loop is processing
+    // the samples and the outer loop is handling the channels.
+    // Alternatively, you can process the samples with the channels
+    // interleaved by keeping the same state.
+    for (int channel = 0; channel < totalNumInputChannels; ++channel)
+    {
+        auto* channelData = buffer.getWritePointer (channel);
+        juce::ignoreUnused (channelData);
+        // ..do something to the data...
+    }
+}
+
+//==============================================================================
+bool AudioPluginAudioProcessor::hasEditor() const
+{
+    return true; // (change this to false if you choose to not supply an editor)
+}
+
+juce::AudioProcessorEditor* AudioPluginAudioProcessor::createEditor()
+{
+    return new AudioPluginAudioProcessorEditor (*this);
+}
+
+//==============================================================================
+void AudioPluginAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
+{
+    // You should use this method to store your parameters in the memory block.
+    // You could do that either as raw data, or use the XML or ValueTree classes
+    // as intermediaries to make it easy to save and load complex data.
+    juce::ignoreUnused (destData);
+}
+
+void AudioPluginAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
+{
+    // You should use this method to restore your parameters from this memory block,
+    // whose contents will have been created by the getStateInformation() call.
+    juce::ignoreUnused (data, sizeInBytes);
+}
+
+//==============================================================================
+// This creates new instances of the plugin..
+juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
+{
+    return new AudioPluginAudioProcessor();
+}

--- a/examples/CMake/AudioPlugin/PluginProcessor.h
+++ b/examples/CMake/AudioPlugin/PluginProcessor.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+
+//==============================================================================
+class AudioPluginAudioProcessor  : public juce::AudioProcessor
+{
+public:
+    //==============================================================================
+    AudioPluginAudioProcessor();
+    ~AudioPluginAudioProcessor() override;
+
+    //==============================================================================
+    void prepareToPlay (double sampleRate, int samplesPerBlock) override;
+    void releaseResources() override;
+
+    bool isBusesLayoutSupported (const BusesLayout& layouts) const override;
+
+    void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+    using AudioProcessor::processBlock;
+
+    //==============================================================================
+    juce::AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override;
+
+    //==============================================================================
+    const juce::String getName() const override;
+
+    bool acceptsMidi() const override;
+    bool producesMidi() const override;
+    bool isMidiEffect() const override;
+    double getTailLengthSeconds() const override;
+
+    //==============================================================================
+    int getNumPrograms() override;
+    int getCurrentProgram() override;
+    void setCurrentProgram (int index) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
+
+    //==============================================================================
+    void getStateInformation (juce::MemoryBlock& destData) override;
+    void setStateInformation (const void* data, int sizeInBytes) override;
+
+private:
+    //==============================================================================
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioPluginAudioProcessor)
+};

--- a/examples/CMake/AudioPlugin/PluginProcessor.h
+++ b/examples/CMake/AudioPlugin/PluginProcessor.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
+#include <tracktion_engine/tracktion_engine.h>
+#include <tracktion_graph/tracktion_graph.h>
 
 //==============================================================================
 class AudioPluginAudioProcessor  : public juce::AudioProcessor

--- a/examples/CMake/CMakeLists.txt
+++ b/examples/CMake/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(AudioPlugin)
+add_subdirectory(ConsoleApp)
+add_subdirectory(GuiApp)

--- a/examples/CMake/ConsoleApp/CMakeLists.txt
+++ b/examples/CMake/ConsoleApp/CMakeLists.txt
@@ -28,11 +28,11 @@ project(CONSOLE_APP_EXAMPLE VERSION 0.0.1)
 # add_subdirectory(JUCE)                    # If you've put JUCE in a subdirectory called JUCE
 
 # `juce_add_console_app` adds an executable target with the name passed as the first argument
-# (ConsoleAppExample here). This target is a normal CMake target, but has a lot of extra properties
+# (TracktionConsoleAppExample here). This target is a normal CMake target, but has a lot of extra properties
 # set up by default. This function accepts many optional arguments. Check the readme at
 # `docs/CMake API.md` in the JUCE repo for the full list.
 
-juce_add_console_app(ConsoleAppExample
+juce_add_console_app(TracktionConsoleAppExample
     PRODUCT_NAME "Console App Example")     # The name of the final executable, which can differ from the target name
 
 # `juce_generate_juce_header` will create a JuceHeader.h for a given target, which will be generated
@@ -41,14 +41,14 @@ juce_add_console_app(ConsoleAppExample
 # JuceHeader is to include all the JUCE module headers for a particular target; if you're happy to
 # include module headers directly, you probably don't need to call this.
 
-# juce_generate_juce_header(ConsoleAppExample)
+# juce_generate_juce_header(TracktionConsoleAppExample)
 
 # `target_sources` adds source files to a target. We pass the target that needs the sources as the
 # first argument, then a visibility parameter for the sources which should normally be PRIVATE.
 # Finally, we supply a list of source files that will be built into the target. This is a standard
 # CMake command.
 
-target_sources(ConsoleAppExample
+target_sources(TracktionConsoleAppExample
     PRIVATE
         Main.cpp)
 
@@ -59,7 +59,7 @@ target_sources(ConsoleAppExample
 # definitions will be visible both to your code, and also the JUCE module code, so for new
 # definitions, pick unique names that are unlikely to collide! This is a standard CMake command.
 
-target_compile_definitions(ConsoleAppExample
+target_compile_definitions(TracktionConsoleAppExample
     PRIVATE
         # JUCE_WEB_BROWSER and JUCE_USE_CURL would be on by default, but you might not need them.
         JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_console_app` call
@@ -79,7 +79,7 @@ target_compile_definitions(ConsoleAppExample
 # resolved automatically. If you'd generated a binary data target above, you would need to link to
 # it here too. This is a standard CMake command.
 
-target_link_libraries(ConsoleAppExample
+target_link_libraries(TracktionConsoleAppExample
     PRIVATE
         # ConsoleAppData            # If you'd created a binary data target, you'd link to it here
         juce::juce_core

--- a/examples/CMake/ConsoleApp/CMakeLists.txt
+++ b/examples/CMake/ConsoleApp/CMakeLists.txt
@@ -83,8 +83,6 @@ target_link_libraries(ConsoleAppExample
     PRIVATE
         # ConsoleAppData            # If you'd created a binary data target, you'd link to it here
         juce::juce_core
-        juce::tracktion_engine
-        juce::tracktion_graph
     PUBLIC
         juce::juce_recommended_config_flags
         juce::juce_recommended_warning_flags)

--- a/examples/CMake/ConsoleApp/CMakeLists.txt
+++ b/examples/CMake/ConsoleApp/CMakeLists.txt
@@ -1,0 +1,90 @@
+# Example Console App CMakeLists.txt
+
+# To get started on a new console app, copy this entire folder (containing this file and C++
+# sources) to a convenient location, and then start making modifications. For other examples of
+# CMakeLists for console apps, check `extras/BinaryBuilder` and `extras/UnitTestRunner` in the JUCE
+# repo.
+
+# The first line of any CMake project should be a call to `cmake_minimum_required`, which checks
+# that the installed CMake will be able to understand the following CMakeLists, and ensures that
+# CMake's behaviour is compatible with the named version. This is a standard CMake command, so more
+# information can be found in the CMake docs.
+
+cmake_minimum_required(VERSION 3.12)
+
+# The top-level CMakeLists.txt file for a project must contain a literal, direct call to the
+# `project()` command. `project()` sets up some helpful variables that describe source/binary
+# directories, and the current project version. This is a standard CMake command.
+
+project(CONSOLE_APP_EXAMPLE VERSION 0.0.1)
+
+# If you've installed JUCE somehow (via a package manager, or directly using the CMake install
+# target), you'll need to tell this project that it depends on the installed copy of JUCE. If you've
+# included JUCE directly in your source tree (perhaps as a submodule), you'll need to tell CMake to
+# include that subdirectory as part of the build.
+
+# find_package(JUCE CONFIG REQUIRED)        # If you've installed JUCE to your system
+# or
+# add_subdirectory(JUCE)                    # If you've put JUCE in a subdirectory called JUCE
+
+# `juce_add_console_app` adds an executable target with the name passed as the first argument
+# (ConsoleAppExample here). This target is a normal CMake target, but has a lot of extra properties
+# set up by default. This function accepts many optional arguments. Check the readme at
+# `docs/CMake API.md` in the JUCE repo for the full list.
+
+juce_add_console_app(ConsoleAppExample
+    PRODUCT_NAME "Console App Example")     # The name of the final executable, which can differ from the target name
+
+# `juce_generate_juce_header` will create a JuceHeader.h for a given target, which will be generated
+# into the build tree. This header should be included with `#include <JuceHeader.h>`. The include
+# path for this header will be automatically added to the target. The main function of the
+# JuceHeader is to include all the JUCE module headers for a particular target; if you're happy to
+# include module headers directly, you probably don't need to call this.
+
+# juce_generate_juce_header(ConsoleAppExample)
+
+# `target_sources` adds source files to a target. We pass the target that needs the sources as the
+# first argument, then a visibility parameter for the sources which should normally be PRIVATE.
+# Finally, we supply a list of source files that will be built into the target. This is a standard
+# CMake command.
+
+target_sources(ConsoleAppExample
+    PRIVATE
+        Main.cpp)
+
+# `target_compile_definitions` adds some preprocessor definitions to our target. In a Projucer
+# project, these might be passed in the 'Preprocessor Definitions' field. JUCE modules also make use
+# of compile definitions to switch certain features on/off, so if there's a particular feature you
+# need that's not on by default, check the module header for the correct flag to set here. These
+# definitions will be visible both to your code, and also the JUCE module code, so for new
+# definitions, pick unique names that are unlikely to collide! This is a standard CMake command.
+
+target_compile_definitions(ConsoleAppExample
+    PRIVATE
+        # JUCE_WEB_BROWSER and JUCE_USE_CURL would be on by default, but you might not need them.
+        JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_console_app` call
+        JUCE_USE_CURL=0)    # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_console_app` call
+
+# If the target needs extra binary assets, they can be added here. The first argument is the name of
+# a new static library target that will include all the binary resources. There is an optional
+# `NAMESPACE` argument that can specify the namespace of the generated binary data class. Finally,
+# the SOURCES argument should be followed by a list of source files that should be built into the
+# static library. These source files can be of any kind (wav data, images, fonts, icons etc.).
+# Conversion to binary-data will happen when the target is built.
+
+# juce_add_binary_data(ConsoleAppData SOURCES ...)
+
+# `target_link_libraries` links libraries and JUCE modules to other libraries or executables. Here,
+# we're linking our executable target to the `juce::juce_core` module. Inter-module dependencies are
+# resolved automatically. If you'd generated a binary data target above, you would need to link to
+# it here too. This is a standard CMake command.
+
+target_link_libraries(ConsoleAppExample
+    PRIVATE
+        # ConsoleAppData            # If you'd created a binary data target, you'd link to it here
+        juce::juce_core
+        juce::tracktion_engine
+        juce::tracktion_graph
+    PUBLIC
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_warning_flags)

--- a/examples/CMake/ConsoleApp/Main.cpp
+++ b/examples/CMake/ConsoleApp/Main.cpp
@@ -1,0 +1,10 @@
+#include <juce_core/juce_core.h>
+
+int main (int argc, char* argv[])
+{
+
+    // Your code goes here!
+    juce::ignoreUnused (argc, argv);
+
+    return 0;
+}

--- a/examples/CMake/GuiApp/CMakeLists.txt
+++ b/examples/CMake/GuiApp/CMakeLists.txt
@@ -1,0 +1,104 @@
+# Example GUI App CMakeLists.txt
+
+# To get started on a new GUI app, copy this entire folder (containing this file and C++ sources) to
+# a convenient location, and then start making modifications. For other examples of CMakeLists for
+# GUI apps, check `extras/Projucer` and `examples/DemoRunner` in the JUCE repo.
+
+# The first line of any CMake project should be a call to `cmake_minimum_required`, which checks
+# that the installed CMake will be able to understand the following CMakeLists, and ensures that
+# CMake's behaviour is compatible with the named version. This is a standard CMake command, so more
+# information can be found in the CMake docs.
+
+cmake_minimum_required(VERSION 3.12)
+
+# The top-level CMakeLists.txt file for a project must contain a literal, direct call to the
+# `project()` command. `project()` sets up some helpful variables that describe source/binary
+# directories, and the current project version. This is a standard CMake command.
+
+project(GUI_APP_EXAMPLE VERSION 0.0.1)
+
+# If you've installed JUCE somehow (via a package manager, or directly using the CMake install
+# target), you'll need to tell this project that it depends on the installed copy of JUCE. If you've
+# included JUCE directly in your source tree (perhaps as a submodule), you'll need to tell CMake to
+# include that subdirectory as part of the build.
+
+# find_package(JUCE CONFIG REQUIRED)        # If you've installed JUCE to your system
+# or
+# add_subdirectory(JUCE)                    # If you've put JUCE in a subdirectory called JUCE
+
+# If your app depends the VST2 SDK, perhaps to host VST2 plugins, CMake needs to be told where
+# to find the SDK on your system. This setup should be done before calling `juce_add_gui_app`.
+
+# juce_set_vst2_sdk_path(...)
+
+# `juce_add_gui_app` adds an executable target with the name passed as the first argument
+# (GuiAppExample here). This target is a normal CMake target, but has a lot of extra properties set
+# up by default. This function accepts many optional arguments. Check the readme at
+# `docs/CMake API.md` in the JUCE repo for the full list.
+
+juce_add_gui_app(GuiAppExample
+    # VERSION ...                       # Set this if the app version is different to the project version
+    # ICON_BIG ...                      # ICON_* arguments specify a path to an image file to use as an icon
+    # ICON_SMALL ...
+    # DOCUMENT_EXTENSIONS ...           # Specify file extensions that should be associated with this app
+    # COMPANY_NAME ...                  # Specify the name of the app's author
+    PRODUCT_NAME "Gui App Example")     # The name of the final executable, which can differ from the target name
+
+# `juce_generate_juce_header` will create a JuceHeader.h for a given target, which will be generated
+# into your build tree. This should be included with `#include <JuceHeader.h>`. The include path for
+# this header will be automatically added to the target. The main function of the JuceHeader is to
+# include all your JUCE module headers; if you're happy to include module headers directly, you
+# probably don't need to call this.
+
+# juce_generate_juce_header(GuiAppExample)
+
+# `target_sources` adds source files to a target. We pass the target that needs the sources as the
+# first argument, then a visibility parameter for the sources which should normally be PRIVATE.
+# Finally, we supply a list of source files that will be built into the target. This is a standard
+# CMake command.
+
+target_sources(GuiAppExample
+    PRIVATE
+        Main.cpp
+        MainComponent.cpp)
+
+# `target_compile_definitions` adds some preprocessor definitions to our target. In a Projucer
+# project, these might be passed in the 'Preprocessor Definitions' field. JUCE modules also make use
+# of compile definitions to switch certain features on/off, so if there's a particular feature you
+# need that's not on by default, check the module header for the correct flag to set here. These
+# definitions will be visible both to your code, and also the JUCE module code, so for new
+# definitions, pick unique names that are unlikely to collide! This is a standard CMake command.
+
+target_compile_definitions(GuiAppExample
+    PRIVATE
+        # JUCE_WEB_BROWSER and JUCE_USE_CURL would be on by default, but you might not need them.
+        JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_gui_app` call
+        JUCE_USE_CURL=0     # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_gui_app` call
+        JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:GuiAppExample,JUCE_PRODUCT_NAME>"
+        JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:GuiAppExample,JUCE_VERSION>")
+
+# If your target needs extra binary assets, you can add them here. The first argument is the name of
+# a new static library target that will include all the binary resources. There is an optional
+# `NAMESPACE` argument that can specify the namespace of the generated binary data class. Finally,
+# the SOURCES argument should be followed by a list of source files that should be built into the
+# static library. These source files can be of any kind (wav data, images, fonts, icons etc.).
+# Conversion to binary-data will happen when your target is built.
+
+# juce_add_binary_data(GuiAppData SOURCES ...)
+
+# `target_link_libraries` links libraries and JUCE modules to other libraries or executables. Here,
+# we're linking our executable target to the `juce::juce_gui_extra` module. Inter-module
+# dependencies are resolved automatically, so `juce_core`, `juce_events` and so on will also be
+# linked automatically. If we'd generated a binary data target above, we would need to link to it
+# here too. This is a standard CMake command.
+
+target_link_libraries(GuiAppExample
+    PRIVATE
+        # GuiAppData            # If we'd created a binary data target, we'd link to it here
+        juce::juce_gui_extra
+        juce::tracktion_engine
+        juce::tracktion_graph
+    PUBLIC
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_lto_flags
+        juce::juce_recommended_warning_flags)

--- a/examples/CMake/GuiApp/CMakeLists.txt
+++ b/examples/CMake/GuiApp/CMakeLists.txt
@@ -32,11 +32,11 @@ project(GUI_APP_EXAMPLE VERSION 0.0.1)
 # juce_set_vst2_sdk_path(...)
 
 # `juce_add_gui_app` adds an executable target with the name passed as the first argument
-# (GuiAppExample here). This target is a normal CMake target, but has a lot of extra properties set
+# (TracktionGuiAppExample here). This target is a normal CMake target, but has a lot of extra properties set
 # up by default. This function accepts many optional arguments. Check the readme at
 # `docs/CMake API.md` in the JUCE repo for the full list.
 
-juce_add_gui_app(GuiAppExample
+juce_add_gui_app(TracktionGuiAppExample
     # VERSION ...                       # Set this if the app version is different to the project version
     # ICON_BIG ...                      # ICON_* arguments specify a path to an image file to use as an icon
     # ICON_SMALL ...
@@ -50,14 +50,14 @@ juce_add_gui_app(GuiAppExample
 # include all your JUCE module headers; if you're happy to include module headers directly, you
 # probably don't need to call this.
 
-# juce_generate_juce_header(GuiAppExample)
+# juce_generate_juce_header(TracktionGuiAppExample)
 
 # `target_sources` adds source files to a target. We pass the target that needs the sources as the
 # first argument, then a visibility parameter for the sources which should normally be PRIVATE.
 # Finally, we supply a list of source files that will be built into the target. This is a standard
 # CMake command.
 
-target_sources(GuiAppExample
+target_sources(TracktionGuiAppExample
     PRIVATE
         Main.cpp
         MainComponent.cpp)
@@ -69,13 +69,13 @@ target_sources(GuiAppExample
 # definitions will be visible both to your code, and also the JUCE module code, so for new
 # definitions, pick unique names that are unlikely to collide! This is a standard CMake command.
 
-target_compile_definitions(GuiAppExample
+target_compile_definitions(TracktionGuiAppExample
     PRIVATE
         # JUCE_WEB_BROWSER and JUCE_USE_CURL would be on by default, but you might not need them.
         JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_gui_app` call
         JUCE_USE_CURL=0     # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_gui_app` call
-        JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:GuiAppExample,JUCE_PRODUCT_NAME>"
-        JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:GuiAppExample,JUCE_VERSION>")
+        JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:TracktionGuiAppExample,JUCE_PRODUCT_NAME>"
+        JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:TracktionGuiAppExample,JUCE_VERSION>")
 
 # If your target needs extra binary assets, you can add them here. The first argument is the name of
 # a new static library target that will include all the binary resources. There is an optional
@@ -92,7 +92,7 @@ target_compile_definitions(GuiAppExample
 # linked automatically. If we'd generated a binary data target above, we would need to link to it
 # here too. This is a standard CMake command.
 
-target_link_libraries(GuiAppExample
+target_link_libraries(TracktionGuiAppExample
     PRIVATE
         # GuiAppData            # If we'd created a binary data target, we'd link to it here
         juce::juce_gui_extra

--- a/examples/CMake/GuiApp/Main.cpp
+++ b/examples/CMake/GuiApp/Main.cpp
@@ -1,0 +1,101 @@
+#include "MainComponent.h"
+
+//==============================================================================
+class GuiAppApplication  : public juce::JUCEApplication
+{
+public:
+    //==============================================================================
+    GuiAppApplication() {}
+
+    // We inject these as compile definitions from the CMakeLists.txt
+    // If you've enabled the juce header with `juce_generate_juce_header(<thisTarget>)`
+    // you could `#include <JuceHeader.h>` and use `ProjectInfo::projectName` etc. instead.
+    const juce::String getApplicationName() override       { return JUCE_APPLICATION_NAME_STRING; }
+    const juce::String getApplicationVersion() override    { return JUCE_APPLICATION_VERSION_STRING; }
+    bool moreThanOneInstanceAllowed() override             { return true; }
+
+    //==============================================================================
+    void initialise (const juce::String& commandLine) override
+    {
+        // This method is where you should put your application's initialisation code..
+        juce::ignoreUnused (commandLine);
+
+        mainWindow.reset (new MainWindow (getApplicationName()));
+    }
+
+    void shutdown() override
+    {
+        // Add your application's shutdown code here..
+
+        mainWindow = nullptr; // (deletes our window)
+    }
+
+    //==============================================================================
+    void systemRequestedQuit() override
+    {
+        // This is called when the app is being asked to quit: you can ignore this
+        // request and let the app carry on running, or call quit() to allow the app to close.
+        quit();
+    }
+
+    void anotherInstanceStarted (const juce::String& commandLine) override
+    {
+        // When another instance of the app is launched while this one is running,
+        // this method is invoked, and the commandLine parameter tells you what
+        // the other instance's command-line arguments were.
+        juce::ignoreUnused (commandLine);
+    }
+
+    //==============================================================================
+    /*
+        This class implements the desktop window that contains an instance of
+        our MainComponent class.
+    */
+    class MainWindow    : public juce::DocumentWindow
+    {
+    public:
+        explicit MainWindow (juce::String name)
+            : DocumentWindow (name,
+                              juce::Desktop::getInstance().getDefaultLookAndFeel()
+                                                          .findColour (ResizableWindow::backgroundColourId),
+                              DocumentWindow::allButtons)
+        {
+            setUsingNativeTitleBar (true);
+            setContentOwned (new MainComponent(), true);
+
+           #if JUCE_IOS || JUCE_ANDROID
+            setFullScreen (true);
+           #else
+            setResizable (true, true);
+            centreWithSize (getWidth(), getHeight());
+           #endif
+
+            setVisible (true);
+        }
+
+        void closeButtonPressed() override
+        {
+            // This is called when the user tries to close this window. Here, we'll just
+            // ask the app to quit when this happens, but you can change this to do
+            // whatever you need.
+            JUCEApplication::getInstance()->systemRequestedQuit();
+        }
+
+        /* Note: Be careful if you override any DocumentWindow methods - the base
+           class uses a lot of them, so by overriding you might break its functionality.
+           It's best to do all your work in your content component instead, but if
+           you really have to override any DocumentWindow methods, make sure your
+           subclass also calls the superclass's method.
+        */
+
+    private:
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainWindow)
+    };
+
+private:
+    std::unique_ptr<MainWindow> mainWindow;
+};
+
+//==============================================================================
+// This macro generates the main() routine that launches the app.
+START_JUCE_APPLICATION (GuiAppApplication)

--- a/examples/CMake/GuiApp/MainComponent.cpp
+++ b/examples/CMake/GuiApp/MainComponent.cpp
@@ -1,0 +1,25 @@
+#include "MainComponent.h"
+
+//==============================================================================
+MainComponent::MainComponent()
+{
+    setSize (600, 400);
+}
+
+//==============================================================================
+void MainComponent::paint (juce::Graphics& g)
+{
+    // (Our component is opaque, so we must completely fill the background with a solid colour)
+    g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
+
+    g.setFont (juce::Font (16.0f));
+    g.setColour (juce::Colours::white);
+    g.drawText ("Hello World!", getLocalBounds(), juce::Justification::centred, true);
+}
+
+void MainComponent::resized()
+{
+    // This is called when the MainComponent is resized.
+    // If you add any child components, this is where you should
+    // update their positions.
+}

--- a/examples/CMake/GuiApp/MainComponent.h
+++ b/examples/CMake/GuiApp/MainComponent.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// CMake builds don't use an AppConfig.h, so it's safe to include juce module headers
+// directly. If you need to remain compatible with Projucer-generated builds, and
+// have called `juce_generate_juce_header(<thisTarget>)` in your CMakeLists.txt,
+// you could `#include <JuceHeader.h>` here instead, to make all your module headers visible.
+#include <juce_gui_extra/juce_gui_extra.h>
+
+//==============================================================================
+/*
+    This component lives inside our window, and this is where you should put all
+    your controls and content.
+*/
+class MainComponent   : public juce::Component
+{
+public:
+    //==============================================================================
+    MainComponent();
+
+    //==============================================================================
+    void paint (juce::Graphics&) override;
+    void resized() override;
+
+private:
+    //==============================================================================
+    // Your private member variables go here...
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainComponent)
+};

--- a/examples/CMake/GuiApp/MainComponent.h
+++ b/examples/CMake/GuiApp/MainComponent.h
@@ -5,6 +5,8 @@
 // have called `juce_generate_juce_header(<thisTarget>)` in your CMakeLists.txt,
 // you could `#include <JuceHeader.h>` here instead, to make all your module headers visible.
 #include <juce_gui_extra/juce_gui_extra.h>
+#include <tracktion_engine/tracktion_engine.h>
+#include <tracktion_graph/tracktion_graph.h>
 
 //==============================================================================
 /*

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(CMake)

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_subdirectory(./juce)
+
+juce_add_modules(
+        INSTALL_PATH "include/JUCE-${JUCE_VERSION}/modules"
+        ALIAS_NAMESPACE juce
+        tracktion_engine
+        tracktion_graph)

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_subdirectory(./juce)
+add_subdirectory(juce)
 
 juce_add_modules(
         INSTALL_PATH "include/JUCE-${JUCE_VERSION}/modules"

--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
@@ -33,7 +33,7 @@ struct ExternalPlugin::ProcessorChangedManager  : public juce::AudioProcessorLis
     {
     }
 
-    void audioProcessorChanged (AudioProcessor* ap) override
+    void audioProcessorChanged (AudioProcessor* ap, const ChangeDetails&) override
     {
         if (plugin.edit.isLoading())
             return;


### PR DESCRIPTION
What I did:
I just copied the style of JUCE to add CMake support, copied JUCE CMake examples with the "Tracktion" prefix for targets, built them with `juce::tracktion_engine` and `juce::tracktion_graph`, included those headers in the source files and everything seems to be working fine. 
I didn't run the tests because the tests require VS2017 and I have VS2019, so hopefully, this is ok.

Bugs encountered:
There was a bug with the latest JUCE version where the method `audioProcessorChanged` of `ExternalPlugin` needed an additional parameter `const ChangeDetails&`, so I just added it in there, so hopefully, that doesn't break anything else. It just seems like an additive feature and not a subtractive one, so I guess it is ok.

Other information:
My JetBrains CLion IDE added some stuff in there as well, so I added JetBrains .gitignore stuff.
Everything I did is in a new branch called `cmake`, so if you accept the pull request the master branch is not going to be affected. 
I didn't add any licensing to the new files, so you might want to do that first.