### PR TITLE
fix track.get()

### DIFF
--- a/modules/tracktion_engine/playback/graph/tracktion_LiveMidiInjectingNode.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_LiveMidiInjectingNode.cpp
@@ -102,7 +102,7 @@ void LiveMidiInjectingNode::injectMessage (MidiMessageArray::MidiMessageWithSour
 //==============================================================================
 void LiveMidiInjectingNode::injectLiveMidiMessage (AudioTrack& at, const MidiMessageArray::MidiMessageWithSource& mm, bool& wasUsed)
 {
-    if (&at != track)
+    if (&at != track.get())
         return;
 
     injectMessage (mm);


### PR DESCRIPTION
Otherwise seeing `Use of overloaded operator ambiguous with te::AudioTrack * and AudioTrack::Ptr` with `ENABLE_EXPERIMENTAL_TRACKTION_GRAPH` enabled