### PR TITLE
EngineBehaviour:   Added a new getEditLimits() which replaces most of…

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,49 +1,40 @@
-Tracktion Engine breaking changes
+# Tracktion Engine breaking changes
 =====================
 
-Develop
-=======
+## Develop
 
-Change
-------
+### Change
 The old AudioNode based engine has been replaced by a new tracktion_graph based engine.
 
-Possible Issues
----------------
+#### Possible Issues
 Some classes will no longer be publicly available such as PlayHead, AudioNode nodes etc.
 
-Workaround
-----------
+#### Workaround
 You'll have to update your code to use the new APIs. In most cases this shouldn't be a
 problem as this is a move to remove the public nature of the engine, the higher level APIs
 that you are using should stay the same. Some arguments to classes such as Plugin have
 changed to remove dependancy on playback specific classed.
 If you really need to use the old engine, see the archive/old_engine branch.
 
-Rationale
----------
+#### Rationale
 The move to the new engine greatly improves CPU performance, especially with multiple
 threads and fixes PDC in a lot of obscure cases such as track to track routing and bussing.
 
-
-Change
-------
+---
+### Change
 The PluginWindowConnection class has been removed to simplify the process of
 creating plugin windows and connecting them to a PluginWindowState.
 
-Possible Issues
----------------
+#### Possible Issues
 PluginWindowState now takes an Edit in its constructor rather than an Engine.
 The UIBehaviour method createPluginWindowConnection has been changed to
 createPluginWindow which now simply needs to create and return a Component
 which will be used to show your plugin UI.
 
-Workaround
-----------
+#### Workaround
 You'll have to update your code to use the new APIs.
 
-Rationale
----------
+#### Rationale
 The old PluginWindowConnection class was an attempt at communicating via IPC
 for sandboxed plugins. However, this is no longer necessary as it's possible
 to encapsulate a sandboxed plugin completely within the juice::AudioProcessor

--- a/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.cpp
@@ -1520,7 +1520,7 @@ String AudioClipBase::canAddClipPlugin (const Plugin::Ptr& p) const
         if (! p->canBeAddedToClip())
             return TRANS("Can't add this kind of plugin to a clip!");
 
-        if (pluginList.size() >= Edit::maxPluginsOnClip)
+        if (pluginList.size() >= edit.engine.getEngineBehaviour().getEditLimits().maxPluginsOnClip)
             return TRANS("Can't add any more plugins to this clip!");
     }
 

--- a/modules/tracktion_engine/model/edit/tracktion_Edit.cpp
+++ b/modules/tracktion_engine/model/edit/tracktion_Edit.cpp
@@ -1640,7 +1640,7 @@ Track::Ptr Edit::insertTrack (TrackInsertPoint insertPoint, juce::ValueTree v, S
 {
     CRASH_TRACER
 
-    if (getAllTracks (*this).size() >= maxNumTracks)
+    if (getAllTracks (*this).size() >= engine.getEngineBehaviour().getEditLimits().maxNumTracks)
         return {};
 
     auto parent = state;

--- a/modules/tracktion_engine/model/edit/tracktion_Edit.h
+++ b/modules/tracktion_engine/model/edit/tracktion_Edit.h
@@ -163,11 +163,6 @@ public:
     /** Returns the maximum length an Edit can be. */
     static EditTimeRange getMaximumEditTimeRange()  { return { 0.0, maximumLength }; }
 
-    static const int maxNumTracks = 400;        /**< The maximum number of Track[s] an Edit can contain. */
-    static const int maxClipsInTrack = 1500;    /**< The maximum number of Clip[s] a Track can contain. */
-    static const int maxPluginsOnClip = 5;      /**< The maximum number of Plugin[s] a Clip can contain. */
-    static const int maxPluginsOnTrack = 16;    /**< The maximum number of Plugin[s] a Track can contain. */
-    static const int maxNumMasterPlugins = 4;   /**< The maximum number of master Plugin[s] and Edit can contain. */
     static const int ticksPerQuarterNote = 960; /**< The number of ticks per quarter note. */
 
     //==============================================================================

--- a/modules/tracktion_engine/model/tracks/tracktion_ClipTrack.cpp
+++ b/modules/tracktion_engine/model/tracks/tracktion_ClipTrack.cpp
@@ -469,7 +469,7 @@ void ClipTrack::addClip (const Clip::Ptr& clip)
 
     if (clip != nullptr)
     {
-        if (clipList->objects.size() < Edit::maxClipsInTrack)
+        if (clipList->objects.size() < edit.engine.getEngineBehaviour().getEditLimits().maxClipsInTrack)
         {
             jassert (findClipForID (clip->itemID) == nullptr);
 

--- a/modules/tracktion_engine/plugins/tracktion_PluginList.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginList.cpp
@@ -180,9 +180,10 @@ bool PluginList::needsConstantBufferSize()
 
 bool PluginList::canInsertPlugin()
 {
-    return ! ((ownerClip != nullptr && size() >= Edit::maxPluginsOnClip)
-              || (ownerTrack != nullptr && size() >= Edit::maxPluginsOnTrack)
-              || (isMasterList (*this) && size() >= edit.engine.getEngineBehaviour().getMaxNumMasterPlugins()));
+    const auto limits = edit.engine.getEngineBehaviour().getEditLimits();
+    return ! ((ownerClip != nullptr && size() >= limits.maxPluginsOnClip)
+              || (ownerTrack != nullptr && size() >= limits.maxPluginsOnTrack)
+              || (isMasterList (*this) && size() >= limits.maxNumMasterPlugins));
 }
 
 void PluginList::insertPlugin (const Plugin::Ptr& plugin, int index, SelectionManager* sm)
@@ -231,10 +232,11 @@ Plugin::Ptr PluginList::insertPlugin (const juce::ValueTree& v, int index)
         }
 
         auto numPlugins = size();
+        const auto limits = edit.engine.getEngineBehaviour().getEditLimits();
 
-        if ((ownerClip != nullptr && numPlugins >= Edit::maxPluginsOnClip)
-             || (ownerTrack != nullptr && numPlugins >= Edit::maxPluginsOnTrack)
-             || (isMasterList (*this) && numPlugins >= edit.engine.getEngineBehaviour().getMaxNumMasterPlugins()))
+        if ((ownerClip != nullptr && numPlugins >= limits.maxPluginsOnClip)
+             || (ownerTrack != nullptr && numPlugins >= limits.maxPluginsOnTrack)
+             || (isMasterList (*this) && numPlugins >= limits.maxNumMasterPlugins))
         {
             jassertfalse;
             return {};

--- a/modules/tracktion_engine/selection/tracktion_Clipboard.cpp
+++ b/modules/tracktion_engine/selection/tracktion_Clipboard.cpp
@@ -445,10 +445,10 @@ void Clipboard::Clips::addSelectedClips (const SelectableList& selectedObjects, 
         return;
 
     auto& ed = clipsToPaste.getFirst()->edit;
-
+    
     auto allTracks = getAllTracks (ed);
 
-    auto firstTrackIndex = Edit::maxNumTracks;
+    auto firstTrackIndex = ed.engine.getEngineBehaviour().getEditLimits().maxNumTracks;
     auto overallStartTime = Edit::maximumLength;
 
     for (auto clip : clipsToPaste)
@@ -522,8 +522,9 @@ void Clipboard::Clips::addAutomation (const juce::Array<TrackSection>& trackSect
     if (range.isEmpty() || trackSections.isEmpty())
         return;
     
-    auto allTracks = getAllTracks (trackSections.getFirst().track->edit);
-    auto firstTrackIndex = Edit::maxNumTracks;
+    auto& edit = trackSections.getFirst().track->edit;
+    auto allTracks = getAllTracks (edit);
+    auto firstTrackIndex = edit.engine.getEngineBehaviour().getEditLimits().maxNumTracks;
     auto overallStartTime = Edit::maximumLength;
 
     for (const auto& trackSection : trackSections)

--- a/modules/tracktion_engine/utilities/tracktion_EngineBehaviour.h
+++ b/modules/tracktion_engine/utilities/tracktion_EngineBehaviour.h
@@ -12,6 +12,19 @@ namespace tracktion_engine
 {
 
 /**
+    Contains the limits of the various elements that can be added to an Edit.
+    @see EngineBehaviour::getEditLimits
+*/
+struct EditLimits
+{
+    int maxNumTracks = 400;        /**< The maximum number of Track[s] an Edit can contain. */
+    int maxClipsInTrack = 1500;    /**< The maximum number of Clip[s] a Track can contain. */
+    int maxPluginsOnClip = 5;      /**< The maximum number of Plugin[s] a Clip can contain. */
+    int maxPluginsOnTrack = 16;    /**< The maximum number of Plugin[s] a Track can contain. */
+    int maxNumMasterPlugins = 4;   /**< The maximum number of master Plugin[s] and Edit can contain. */
+};
+
+/**
     Provides custom handlers to control various aspects of the engine's behaviour.
     Create a subclass of EngineBehaviour to customise how the engine operates
 */
@@ -120,8 +133,8 @@ public:
     virtual bool arePluginsRemappedWhenTempoChanges()                               { return true; }
     virtual void setPluginsRemappedWhenTempoChanges (bool)                          {}
 
-    /** Should return the maximum number of plugins that can be added to the master bus. */
-    virtual int getMaxNumMasterPlugins()                                            { return 4; }
+    /** Should return the maximum number of elements that can be added to an Edit. */
+    virtual EditLimits getEditLimits()                                              { return {}; }
 
     /** If this returns true, it means that the length (in seconds) of one "beat" at
         any point in an edit is considered to be the length of one division in the current


### PR DESCRIPTION
… the static members of Edit. N.B. this also removes EngineBehaviour::getMaxNumMasterPlugins