### PR TITLE
Add fixes for raspberry pi builds

### DIFF
--- a/modules/tracktion_graph/utilities/tracktion_Allocation.test.cpp
+++ b/modules/tracktion_graph/utilities/tracktion_Allocation.test.cpp
@@ -156,14 +156,14 @@ private:
             std::thread t3 ([this, &intVec1]
                             {
                                 intVec1.clear();
-                                expectEquals<size_t> (intVec1.size(), 0);
-                                expectGreaterThan<size_t> (intVec1.capacity(), 0);
+                                expect (intVec1.size() == 0);
+                                expect (intVec1.capacity() > 0);
                                 intVec1.shrink_to_fit();
-                                expectEquals<size_t> (intVec1.capacity(), 0);
+                                expect (intVec1.capacity() == 0);
                             });
             t3.join();
-            expectEquals<size_t> (intVec1.size(), 0);
-            expectEquals<size_t> (intVec1.capacity(), 0);
+            expect (intVec1.size() == 0);
+            expect (intVec1.capacity() == 0);
         }
         
         beginTest ("rpallocator multi-thread");


### PR DESCRIPTION
This PR adds fixes discussed in [this JUCE forum post](https://forum.juce.com/t/cant-build-guiapp-with-tracktion-engine-on-raspberry-pi/50068/14) in order to get tracktion engine building on 32 bit ARM targets. 