### PR TITLE
provide fix for rpallocator for newer compilers/stdlibs

### DIFF
--- a/modules/3rd_party/rpmalloc/rpallocator.h
+++ b/modules/3rd_party/rpmalloc/rpallocator.h
@@ -170,3 +170,8 @@ private:
         thread_local details::ScopedRPThreadFinaliser init;
     }
 };
+
+template <typename T, typename U>
+bool operator==(const rpallocator <T>&, const rpallocator <U>&) { return true; }
+template <typename T, typename U>
+bool operator!=(const rpallocator <T>&, const rpallocator <U>&) { return false; }


### PR DESCRIPTION
Currently the engine is unable to be built using newer compilers/stdlibs such as GCC 11.2.0 and clang 14 (which are what is available in the newest LTS of Ubuntu 22.04). The compiler error is listed below:
```
home/stone/development/tracktion_engine/modules/tracktion_graph/utilities/tracktion_Allocation.test.cpp:161:54:   required from here
/usr/include/c++/11/bits/stl_vector.h:1483:9: error: no match for ‘operator==’ (operand types are ‘std::_Vector_base<int, rpallocator<int> >::_Tp_alloc_type’ {aka ‘std::allocator_traits<rpallocator<int> >::rebind_alloc<int>’} and ‘std::_Vector_base<int, rpallocator<int> >::_Tp_alloc_type’ {aka ‘std::allocator_traits<rpallocator<int> >::rebind_alloc<int>’})
 1483 |         __glibcxx_assert(_Alloc_traits::propagate_on_container_swap::value
 ```
 
 The fix for this is to define operators for `==` and `!=`. The [docs](https://en.cppreference.com/w/cpp/named_req/Allocator) have this to say about `==`
> true only if the storage allocated by the allocator a1 can be deallocated through a2.
> Establishes reflexive, symmetric, and transitive relationship.
> Does not throw exceptions. 

I have returned true for == in this PR, but i dont know enough about these allocators to say whether or not storage allocated by one  can be deallocated by another. Hopefully you can provide some guidance as to what the desired behavior is for the allocator.

The fix does work, and I can confirm the engine compiles on GCC 11.2.0 and clang 14