### PR TITLE
Fix for misplaced click emphasis of firstBeatOfBar

### DIFF
--- a/modules/tracktion_engine/playback/graph/tracktion_ClickNode.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_ClickNode.cpp
@@ -118,8 +118,9 @@ namespace
         const auto beats = tempoPosition.getBeats().inBeats();
         int beat = static_cast<int> (std::floor (beats));
         const auto beatTime = sequence.toTime (BeatPosition::fromBeats (beat));
-        const bool isFirstBeatOfBar = sequence.toBarsAndBeats (beatTime).getWholeBeats() == 0;
-
+        int numerator = tempoPosition.getTimeSignature().numerator;
+        const bool isFirstBeatOfBar = (beat % numerator) == 0;
+        
         return { beatTime, isFirstBeatOfBar };
     }
 }


### PR DESCRIPTION
Summary:
Changed bool isFirstBeatOfBar from beatTime getWholeBeats() to beat with a modulus of the time signature numerator.

Reasoning:
Periodically I observed the click emphasis on the first beat of a bar being misplaced.  ie. the second beat or last beat of a bar were emphasised instead of the expected first beat.

The issue seems to originate from getWholeBeats() not being equal to 0 when expected.

In general this issue presented more often with bpm values with lots of decimal places. eg 157.1396273744468 at 4/4 timing.

As of now I have not managed to reproduce the same problem in testing my adjusted code.