### PR TITLE
Feature/auv3

### DIFF
--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
@@ -22,25 +22,21 @@ juce::String createIdentifierString (const juce::PluginDescription& d)
     return d.pluginFormatName + "-" + d.name + getDeprecatedPluginDescSuffix (d);
 }
 
-struct ExternalPlugin::ProcessorChangedManager  : public juce::AudioProcessorListener,
+class ExternalPlugin::ProcessorChangedManager   : public juce::AudioProcessorListener,
                                                   private juce::AsyncUpdater
 {
-    ProcessorChangedManager (ExternalPlugin& p) : plugin (p)
+public:
+    ProcessorChangedManager (ExternalPlugin& p, juce::AudioPluginInstance& i)
+        : plugin (p), instance (i)
     {
-        if (auto pi = plugin.getAudioPluginInstance())
-            pi->addListener (this);
-        else
-            jassertfalse;
+        instance.addListener (this);
     }
 
     ~ProcessorChangedManager() override
     {
         cancelPendingUpdate();
 
-        if (auto pi = plugin.getAudioPluginInstance())
-            pi->removeListener (this);
-        else
-            jassertfalse;
+        instance.removeListener (this);
     }
 
     void audioProcessorParameterChanged (juce::AudioProcessor*, int, float) override
@@ -61,9 +57,9 @@ struct ExternalPlugin::ProcessorChangedManager  : public juce::AudioProcessorLis
         triggerAsyncUpdate();
     }
 
-    ExternalPlugin& plugin;
-
 private:
+    ExternalPlugin& plugin;
+    juce::AudioPluginInstance& instance;
     JUCE_DECLARE_NON_COPYABLE (ProcessorChangedManager)
 
     static bool hasAnyModifiers (AutomatableEditItem& item)
@@ -143,6 +139,41 @@ private:
 };
 
 //==============================================================================
+class ExternalPlugin::LoadedInstance
+{
+public:
+    static std::unique_ptr<LoadedInstance> create (ExternalPlugin& ep, std::unique_ptr<juce::AudioPluginInstance> pi)
+    {
+        assert (pi);
+
+        // N.B. We can't use make_unique here as make_unique would need to be a friend of LoadedInstance
+        std::unique_ptr<LoadedInstance> loadedInstance (new LoadedInstance());
+        loadedInstance->pluginInstance = std::move (pi);
+        loadedInstance->processorChangedManager = std::make_unique<ProcessorChangedManager> (ep, *loadedInstance->pluginInstance);
+
+        return loadedInstance;
+    }
+
+    juce::AudioPluginInstance& getInstance()
+    {
+        return *pluginInstance;
+    }
+
+    std::unique_ptr<juce::AudioPluginInstance> releaseInstance()
+    {
+        processorChangedManager.reset();
+        return std::move (pluginInstance);
+    }
+
+private:
+    std::unique_ptr<juce::AudioPluginInstance> pluginInstance;
+    std::unique_ptr<ProcessorChangedManager> processorChangedManager;
+
+    LoadedInstance() = default;
+};
+
+
+//==============================================================================
 struct AsyncPluginDeleter  : private juce::Timer,
                              private juce::DeletedAtShutdown
 {
@@ -160,11 +191,11 @@ struct AsyncPluginDeleter  : private juce::Timer,
 
     JUCE_DECLARE_SINGLETON (AsyncPluginDeleter, false)
 
-    void deletePlugin (juce::AudioPluginInstance* p)
+    void deletePlugin (std::unique_ptr<juce::AudioPluginInstance> p)
     {
-        if (p != nullptr)
+        if (p)
         {
-            plugins.add (p);
+            plugins.add (p.release());
             startTimer (100);
         }
     }
@@ -558,7 +589,7 @@ juce::ValueTree ExternalPlugin::create (Engine& e, const juce::PluginDescription
 
 juce::String ExternalPlugin::getLoadError()
 {
-    if (pluginInstance != nullptr)
+    if (hasLoadedInstance)
         return {};
 
     if (loadError.isEmpty())
@@ -592,10 +623,9 @@ void ExternalPlugin::forceFullReinitialise()
     initialiseFully();
     changed();
 
-    if (isInstancePrepared && pluginInstance->getSampleRate() > 0 && pluginInstance->getBlockSize() > 0)
-    {
-        pluginInstance->prepareToPlay (pluginInstance->getSampleRate(), pluginInstance->getBlockSize());
-    }
+    if (isInstancePrepared)
+        if (auto pi = getAudioPluginInstance(); pi->getSampleRate() > 0 && pi->getBlockSize() > 0)
+            pi->prepareToPlay (pi->getSampleRate(), pi->getBlockSize());
 
     edit.restartPlayback();
     SelectionManager::refreshAllPropertyPanelsShowing (*this);
@@ -619,9 +649,9 @@ void ExternalPlugin::buildParameterList()
     addAutomatableParameter (dryGain);
     addAutomatableParameter (wetGain);
 
-    if (pluginInstance != nullptr)
+    if (auto pi = getAudioPluginInstance())
     {
-        auto& parameters = pluginInstance->getParameters();
+        auto& parameters = pi->getParameters();
         jassert (parameters.size() < 80000);
         const auto maxAutoParams = std::min (80000, parameters.size());
 
@@ -629,7 +659,7 @@ void ExternalPlugin::buildParameterList()
         {
             auto parameter = parameters.getUnchecked (i);
 
-            if (parameter->isAutomatable() && ! isParameterBlacklisted (*this, *pluginInstance, *parameter))
+            if (parameter->isAutomatable() && ! isParameterBlacklisted (*this, *pi, *parameter))
             {
                 auto nm = parameter->getName (1024);
 
@@ -802,7 +832,7 @@ void ExternalPlugin::processingChanged()
 
     if (processing)
     {
-        if (pluginInstance == nullptr)
+        if (! getAudioPluginInstance())
             forceFullReinitialise();
     }
     else
@@ -823,7 +853,9 @@ void ExternalPlugin::doFullInitialisation()
         identiferString = createIdentifierString (desc);
         updateDebugName();
 
-        if (processing && pluginInstance == nullptr && engine.getEngineBehaviour().shouldLoadPlugin (*this))
+
+        if (processing && ! hasLoadedInstance
+            && engine.getEngineBehaviour().shouldLoadPlugin (*this))
         {
             if (isDisabled())
                 return;
@@ -834,20 +866,20 @@ void ExternalPlugin::doFullInitialisation()
             callBlocking ([this, &foundDesc]
             {
                 CRASH_TRACER_PLUGIN (getDebugName());
-                loadError = createPluginInstance (*foundDesc);
+                createPluginInstance (*foundDesc);
             });
 
-            if (pluginInstance != nullptr)
+            if (auto pi = getAudioPluginInstance())
             {
                #if JUCE_PLUGINHOST_VST
-                if (auto xml = juce::VSTPluginFormat::getVSTXML (pluginInstance.get()))
+                if (auto xml = juce::VSTPluginFormat::getVSTXML (pi))
                     vstXML.reset (VSTXML::createFor (*xml));
 
-                juce::VSTPluginFormat::setExtraFunctions (pluginInstance.get(), new ExtraVSTCallbacks (edit));
+                juce::VSTPluginFormat::setExtraFunctions (pi, new ExtraVSTCallbacks (edit));
                #endif
 
-                pluginInstance->setPlayHead (playhead.get());
-                supportsMPE = pluginInstance->supportsMPE();
+                pi->setPlayHead (playhead.get());
+                supportsMPE = pi->supportsMPE();
 
                 engine.getEngineBehaviour().doAdditionalInitialisation (*this);
             }
@@ -866,13 +898,9 @@ void ExternalPlugin::trackPropertiesChanged()
         if (pluginRef == nullptr)
             return;
 
-        if (auto t = getOwnerTrack(); t != nullptr && pluginInstance != nullptr)
-        {
-            auto n = t->getName();
-            auto c = t->getColour();
-
-            pluginInstance->updateTrackProperties ({n, c});
-        }
+        if (auto t = getOwnerTrack(); t != nullptr)
+            if (auto pi = getAudioPluginInstance())
+                pi->updateTrackProperties ({ t->getName(), t->getColour() });
     });
 }
 
@@ -888,7 +916,6 @@ ExternalPlugin::~ExternalPlugin()
     dryGain->detachFromCurrentValue();
     wetGain->detachFromCurrentValue();
 
-    const juce::ScopedLock sl (lock);
     deletePluginInstance();
 }
 
@@ -917,20 +944,20 @@ void ExternalPlugin::flushPluginStateToValueTree()
         state.setProperty (IDs::filename, desc.fileOrIdentifier, um);
     }
 
-    if (pluginInstance != nullptr)
+    if (auto pi = getAudioPluginInstance())
     {
-        if (pluginInstance->getNumPrograms() > 0)
-            state.setProperty (IDs::programNum,  pluginInstance->getCurrentProgram(), um);
+        if (pi->getNumPrograms() > 0)
+            state.setProperty (IDs::programNum,  pi->getCurrentProgram(), um);
 
         TRACKTION_ASSERT_MESSAGE_THREAD
         juce::MemoryBlock chunk;
 
-        pluginInstance->suspendProcessing (true);
-        pluginInstance->getStateInformation (chunk);
+        pi->suspendProcessing (true);
+        pi->getStateInformation (chunk);
         saveChangedParametersToState();
-        pluginInstance->suspendProcessing (false);
+        pi->suspendProcessing (false);
 
-        engine.getEngineBehaviour().saveCustomPluginProperties (state, *pluginInstance, um);
+        engine.getEngineBehaviour().saveCustomPluginProperties (state, *pi, um);
 
         if (chunk.getSize() > 0)
             state.setProperty (IDs::state, chunk.toBase64Encoding(), um);
@@ -980,7 +1007,8 @@ void ExternalPlugin::restorePluginStateFromValueTree (const juce::ValueTree& v)
         }
     }
 
-    if (pluginInstance != nullptr && s.isNotEmpty())
+    if (auto pi = getAudioPluginInstance();
+        pi && s.isNotEmpty())
     {
         CRASH_TRACER_PLUGIN (getDebugName());
 
@@ -991,7 +1019,7 @@ void ExternalPlugin::restorePluginStateFromValueTree (const juce::ValueTree& v)
         chunk.fromBase64Encoding (s);
 
         if (chunk.getSize() > 0)
-            callBlocking ([this, &chunk]() { pluginInstance->setStateInformation (chunk.getData(), (int) chunk.getSize()); });
+            callBlocking ([&pi, &chunk] { pi->setStateInformation (chunk.getData(), (int) chunk.getSize()); });
     }
 }
 
@@ -1008,17 +1036,21 @@ void ExternalPlugin::updateFromMirroredPluginIfNeeded (Plugin& changedPlugin)
 {
     TRACKTION_ASSERT_MESSAGE_THREAD
 
-    if (changedPlugin.itemID == masterPluginID)
+    if (changedPlugin.itemID != masterPluginID)
+        return;
+
+    if (auto pi = getAudioPluginInstance())
     {
         if (auto other = dynamic_cast<ExternalPlugin*> (&changedPlugin))
         {
-            if (other->pluginInstance != nullptr && other->desc.isDuplicateOf (desc))
+            if (auto otherInstance = other->getAudioPluginInstance();
+                otherInstance && other->desc.isDuplicateOf (desc))
             {
                 juce::MemoryBlock chunk;
-                other->pluginInstance->getStateInformation (chunk);
+                otherInstance->getStateInformation (chunk);
 
                 if (chunk.getSize() > 0)
-                    pluginInstance->setStateInformation (chunk.getData(), (int) chunk.getSize());
+                    pi->setStateInformation (chunk.getData(), (int) chunk.getSize());
             }
         }
     }
@@ -1121,14 +1153,14 @@ void ExternalPlugin::initialise (const PluginInitialisationInfo& info)
 {
     CRASH_TRACER_PLUGIN (getDebugName());
 
-    const juce::ScopedLock sl (lock);
+    const juce::ScopedLock sl (processMutex);
 
     if (mpeRemapper == nullptr)
         mpeRemapper = std::make_unique<MPEChannelRemapper>();
 
     mpeRemapper->reset();
 
-    if (pluginInstance != nullptr)
+    if (auto pi = getAudioPluginInstance())
     {
         // This used to releaseResources() before calling prepareToPlay().
         // However, with VST3, releaseResources() shuts down the MIDI
@@ -1136,29 +1168,29 @@ void ExternalPlugin::initialise (const PluginInitialisationInfo& info)
         // breaks all synths.
         if (! isInstancePrepared)
         {
-            pluginInstance->prepareToPlay (info.sampleRate, info.blockSizeSamples);
+            pi->prepareToPlay (info.sampleRate, info.blockSizeSamples);
             isInstancePrepared = true;
         }
         else if (info.sampleRate != lastSampleRate || info.blockSizeSamples != lastBlockSizeSamples)
         {
-            pluginInstance->prepareToPlay (info.sampleRate, info.blockSizeSamples);
+            pi->prepareToPlay (info.sampleRate, info.blockSizeSamples);
         }
 
         lastSampleRate = info.sampleRate;
         lastBlockSizeSamples = info.blockSizeSamples;
 
-        latencySamples = pluginInstance->getLatencySamples();
+        latencySamples = pi->getLatencySamples();
         latencySeconds = latencySamples / info.sampleRate;
 
         if (! desc.hasSharedContainer)
         {
-            desc = pluginInstance->getPluginDescription();
+            desc = pi->getPluginDescription();
             updateDebugName();
         }
 
-        pluginInstance->setPlayHead (nullptr);
+        pi->setPlayHead (nullptr);
         playhead = std::make_unique<PluginPlayHead> (*this);
-        pluginInstance->setPlayHead (playhead.get());
+        pi->setPlayHead (playhead.get());
     }
     else
     {
@@ -1171,12 +1203,12 @@ void ExternalPlugin::initialise (const PluginInitialisationInfo& info)
 
 void ExternalPlugin::deinitialise()
 {
-    if (pluginInstance != nullptr)
+    if (auto pi = getAudioPluginInstance())
     {
         CRASH_TRACER_PLUGIN (getDebugName());
 
-        const juce::ScopedLock sl (lock);
-        pluginInstance->setPlayHead (nullptr); // must be done first!
+        const juce::ScopedLock sl (processMutex);
+        pi->setPlayHead (nullptr); // must be done first!
 
         if (playhead != nullptr)
             playhead->setCurrentContext (nullptr);
@@ -1185,11 +1217,11 @@ void ExternalPlugin::deinitialise()
 
 void ExternalPlugin::reset()
 {
-    if (pluginInstance != nullptr)
+    if (auto pi = getAudioPluginInstance())
     {
         CRASH_TRACER_PLUGIN (getDebugName());
-        const juce::ScopedLock sl (lock);
-        pluginInstance->reset();
+        const juce::ScopedLock sl (processMutex);
+        pi->reset();
     }
 }
 
@@ -1199,8 +1231,8 @@ void ExternalPlugin::setEnabled (bool shouldEnable)
 
     if (shouldEnable != isEnabled())
     {
-        if (pluginInstance != nullptr)
-            pluginInstance->reset();
+        if (auto pi = getAudioPluginInstance())
+            pi->reset();
 
         propertiesChanged();
     }
@@ -1301,11 +1333,17 @@ void ExternalPlugin::applyToBuffer (const PluginRenderContext& fc)
 {
     const bool processedBypass = fc.allowBypassedProcessing && ! isEnabled();
 
-    if (pluginInstance != nullptr && (processedBypass || isEnabled()))
+    if (! hasLoadedInstance.load (std::memory_order_acquire))
+        return;
+
+    if (processedBypass || isEnabled())
     {
+        assert (loadedInstance);
         CRASH_TRACER_PLUGIN (getDebugName());
-        const juce::ScopedLock sl (lock);
+
+        const juce::ScopedLock sl (processMutex);
         jassert (isInstancePrepared);
+        auto pi = getAudioPluginInstance();
 
         if (playhead != nullptr)
             playhead->setCurrentContext (&fc);
@@ -1320,13 +1358,13 @@ void ExternalPlugin::applyToBuffer (const PluginRenderContext& fc)
             auto destNumChans = fc.destBuffer->getNumChannels();
             jassert (destNumChans > 0);
 
-            auto numInputChannels = pluginInstance->getTotalNumInputChannels();
-            auto numOutputChannels = pluginInstance->getTotalNumOutputChannels();
+            auto numInputChannels = pi->getTotalNumInputChannels();
+            auto numOutputChannels = pi->getTotalNumOutputChannels();
             auto numChansToProcess = std::max (std::max (1, numInputChannels), numOutputChannels);
 
             if (destNumChans == numChansToProcess)
             {
-                processPluginBlock (fc, processedBypass);
+                processPluginBlock (*pi, fc, processedBypass);
             }
             else
             {
@@ -1358,7 +1396,7 @@ void ExternalPlugin::applyToBuffer (const PluginRenderContext& fc)
                 fc2.destBuffer = &asb.buffer;
                 fc2.bufferStartSample = 0;
 
-                processPluginBlock (fc2, processedBypass);
+                processPluginBlock (*pi, fc2, processedBypass);
 
                 // Copy sample data back clearing unprocessed channels
                 for (int i = 0; i < destNumChans; ++i)
@@ -1374,13 +1412,13 @@ void ExternalPlugin::applyToBuffer (const PluginRenderContext& fc)
         }
         else
         {
-            AudioScratchBuffer asb (std::max (pluginInstance->getTotalNumInputChannels(),
-                                              pluginInstance->getTotalNumOutputChannels()), fc.bufferNumSamples);
+            AudioScratchBuffer asb (std::max (pi->getTotalNumInputChannels(),
+                                              pi->getTotalNumOutputChannels()), fc.bufferNumSamples);
 
             if (processedBypass)
-                pluginInstance->processBlockBypassed (asb.buffer, midiBuffer);
+                pi->processBlockBypassed (asb.buffer, midiBuffer);
             else
-                pluginInstance->processBlock (asb.buffer, midiBuffer);
+                pi->processBlock (asb.buffer, midiBuffer);
         }
 
         if (fc.bufferForMidiMessages != nullptr)
@@ -1405,8 +1443,10 @@ void ExternalPlugin::applyToBuffer (const PluginRenderContext& fc)
     }
 }
 
-void ExternalPlugin::processPluginBlock (const PluginRenderContext& fc, bool processedBypass)
+void ExternalPlugin::processPluginBlock (juce::AudioPluginInstance& pluginInstance, const PluginRenderContext& fc, bool processedBypass)
 {
+    // N.B. The processMutex is already locked by the calling function
+
     juce::AudioBuffer<float> asb (fc.destBuffer->getArrayOfWritePointers(), fc.destBuffer->getNumChannels(),
                                   fc.bufferStartSample, fc.bufferNumSamples);
 
@@ -1416,9 +1456,9 @@ void ExternalPlugin::processPluginBlock (const PluginRenderContext& fc, bool pro
     if (dry <= 0.00004f)
     {
         if (processedBypass)
-            pluginInstance->processBlockBypassed (asb, midiBuffer);
+            pluginInstance.processBlockBypassed (asb, midiBuffer);
         else
-            pluginInstance->processBlock (asb, midiBuffer);
+            pluginInstance.processBlock (asb, midiBuffer);
 
         zeroDenormalisedValuesIfNeeded (asb);
 
@@ -1434,9 +1474,9 @@ void ExternalPlugin::processPluginBlock (const PluginRenderContext& fc, bool pro
             dryAudio.buffer.copyFrom (i, 0, asb, i, 0, fc.bufferNumSamples);
 
         if (processedBypass)
-            pluginInstance->processBlockBypassed (asb, midiBuffer);
+            pluginInstance.processBlockBypassed (asb, midiBuffer);
         else
-            pluginInstance->processBlock (asb, midiBuffer);
+            pluginInstance.processBlock (asb, midiBuffer);
 
         zeroDenormalisedValuesIfNeeded (asb);
 
@@ -1457,7 +1497,7 @@ int ExternalPlugin::getNumOutputChannelsGivenInputs (int)
 void ExternalPlugin::getChannelNames (juce::StringArray* ins,
                                       juce::StringArray* outs)
 {
-    if (pluginInstance != nullptr)
+    if (auto pi = getAudioPluginInstance())
     {
         CRASH_TRACER_PLUGIN (getDebugName());
 
@@ -1469,22 +1509,22 @@ void ExternalPlugin::getChannelNames (juce::StringArray* ins,
 
         if (ins != nullptr)
         {
-            const int num = pluginInstance->getTotalNumInputChannels();
+            const int num = pi->getTotalNumInputChannels();
 
             for (int i = 0; i < num; ++i)
             {
-                auto name = getChannelName (pluginInstance->getBus (true, 0), i);
+                auto name = getChannelName (pi->getBus (true, 0), i);
                 ins->add (name.isNotEmpty() ? name : TRANS("Unnamed"));
             }
         }
 
         if (outs != nullptr)
         {
-            const int num = pluginInstance->getTotalNumOutputChannels();
+            const int num = pi->getTotalNumOutputChannels();
 
             for (int i = 0; i < num; ++i)
             {
-                auto name = getChannelName (pluginInstance->getBus (false, 0), i);
+                auto name = getChannelName (pi->getBus (false, 0), i);
                 outs->add (name.isNotEmpty() ? name : TRANS("Unnamed"));
             }
         }
@@ -1494,13 +1534,17 @@ void ExternalPlugin::getChannelNames (juce::StringArray* ins,
 bool ExternalPlugin::noTail()
 {
     CRASH_TRACER_PLUGIN (getDebugName());
-    return pluginInstance == nullptr || pluginInstance->getTailLengthSeconds() <= 0.0;
+    return getTailLength() <= 0.0;
 }
 
 double ExternalPlugin::getTailLength() const
 {
     CRASH_TRACER_PLUGIN (getDebugName());
-    return pluginInstance ? pluginInstance->getTailLengthSeconds() : 0.0;
+
+    if (auto pi = getAudioPluginInstance())
+        return pi->getTailLengthSeconds();
+
+    return 0.0;
 }
 
 //==============================================================================
@@ -1525,12 +1569,18 @@ juce::String ExternalPlugin::getSelectableDescription()
 //==============================================================================
 int ExternalPlugin::getNumPrograms() const
 {
-    return pluginInstance ? pluginInstance->getNumPrograms() : 0;
+    if (auto pi = getAudioPluginInstance())
+        return pi->getNumPrograms();
+
+    return 0;
 }
 
 int ExternalPlugin::getCurrentProgram() const
 {
-    return pluginInstance ? pluginInstance->getCurrentProgram() : 0;
+    if (auto pi = getAudioPluginInstance())
+        return pi->getCurrentProgram();
+
+    return 0;
 }
 
 juce::String ExternalPlugin::getProgramName (int index)
@@ -1538,8 +1588,8 @@ juce::String ExternalPlugin::getProgramName (int index)
     if (index == getCurrentProgram())
         return getCurrentProgramName();
 
-    if (pluginInstance != nullptr)
-        return pluginInstance->getProgramName (index);
+    if (auto pi = getAudioPluginInstance())
+        return pi->getProgramName (index);
 
     return {};
 }
@@ -1549,8 +1599,8 @@ bool ExternalPlugin::hasNameForMidiNoteNumber (int note, int midiChannel, juce::
     ignoreUnused (note, midiChannel, name);
    #if TRACKTION_JUCE
     if (takesMidiInput())
-        if (pluginInstance != nullptr)
-            return pluginInstance->hasNameForMidiNoteNumber (note, midiChannel, name);
+        if (auto pi = getAudioPluginInstance())
+            return pi->hasNameForMidiNoteNumber (note, midiChannel, name);
    #endif
 
     return false;
@@ -1585,29 +1635,34 @@ juce::String ExternalPlugin::getNumberedProgramName (int i)
 
 juce::String ExternalPlugin::getCurrentProgramName()
 {
-    return pluginInstance ? pluginInstance->getProgramName (pluginInstance->getCurrentProgram())
-                          : juce::String();
+    if (auto pi = getAudioPluginInstance())
+        return pi->getProgramName (pi->getCurrentProgram());
+
+    return {};
 }
 
 void ExternalPlugin::setCurrentProgramName (const juce::String& name)
 {
     CRASH_TRACER_PLUGIN (getDebugName());
 
-    if (pluginInstance != nullptr)
-        pluginInstance->changeProgramName (pluginInstance->getCurrentProgram(), name);
+    if (auto pi = getAudioPluginInstance())
+        pi->changeProgramName (pi->getCurrentProgram(), name);
 }
 
 void ExternalPlugin::setCurrentProgram (int index, bool sendChangeMessage)
 {
-    if (pluginInstance != nullptr && getNumPrograms() > 0)
+    if (auto pi = getAudioPluginInstance())
     {
+        if (getNumPrograms() == 0)
+            return;
+
         CRASH_TRACER_PLUGIN (getDebugName());
 
         index = juce::jlimit (0, getNumPrograms() - 1, index);
 
         if (index != getCurrentProgram())
         {
-            pluginInstance->setCurrentProgram (index);
+            pi->setCurrentProgram (index);
             state.setProperty (IDs::programNum, index, nullptr);
 
             if (sendChangeMessage)
@@ -1621,12 +1676,15 @@ void ExternalPlugin::setCurrentProgram (int index, bool sendChangeMessage)
 
 bool ExternalPlugin::takesMidiInput()
 {
-    return pluginInstance && pluginInstance->acceptsMidi();
+    if (auto pi = getAudioPluginInstance())
+        return pi->acceptsMidi();
+
+    return false;
 }
 
 bool ExternalPlugin::isMissing()
 {
-    return ! isDisabled() && pluginInstance == nullptr;
+    return ! isDisabled() && ! hasLoadedInstance;
 }
 
 bool ExternalPlugin::isDisabled()
@@ -1634,12 +1692,25 @@ bool ExternalPlugin::isDisabled()
     return engine.getEngineBehaviour().isPluginDisabled (identiferString);
 }
 
-int ExternalPlugin::getNumInputs() const     { return pluginInstance ? pluginInstance->getTotalNumInputChannels() : 0; }
-int ExternalPlugin::getNumOutputs() const    { return pluginInstance ? pluginInstance->getTotalNumOutputChannels() : 0; }
+int ExternalPlugin::getNumInputs() const
+{
+    if (auto pi = getAudioPluginInstance())
+        return pi->getTotalNumInputChannels();
+
+    return 0;
+}
+
+int ExternalPlugin::getNumOutputs() const
+{
+    if (auto pi = getAudioPluginInstance())
+        return pi->getTotalNumOutputChannels();
+
+    return 0;
+}
 
 bool ExternalPlugin::setBusesLayout (juce::AudioProcessor::BusesLayout layout)
 {
-    if (pluginInstance != nullptr)
+    if (auto pi = getAudioPluginInstance())
     {
         std::unique_ptr<Edit::ScopedRenderStatus> srs;
 
@@ -1650,10 +1721,10 @@ bool ExternalPlugin::setBusesLayout (juce::AudioProcessor::BusesLayout layout)
 
         // We need to release resources before changing the bus layout
         // prepareToPlay will be called when the above ScopedRenderStatus goes out of scope
-        pluginInstance->releaseResources();
+        pi->releaseResources();
         isInstancePrepared = false;
 
-        if (pluginInstance->setBusesLayout (layout))
+        if (pi->setBusesLayout (layout))
         {
             if (! edit.isLoading())
             {
@@ -1672,9 +1743,9 @@ bool ExternalPlugin::setBusesLayout (juce::AudioProcessor::BusesLayout layout)
 
 bool ExternalPlugin::setBusLayout (juce::AudioChannelSet set, bool isInput, int busIndex)
 {
-    if (pluginInstance != nullptr)
+    if (auto pi = getAudioPluginInstance())
     {
-        if (auto bus = pluginInstance->getBus (isInput, busIndex))
+        if (auto bus = pi->getBus (isInput, busIndex))
         {
             std::unique_ptr<Edit::ScopedRenderStatus> srs;
 
@@ -1683,7 +1754,7 @@ bool ExternalPlugin::setBusLayout (juce::AudioChannelSet set, bool isInput, int 
 
             // We need to release resources before changing the bus layout
             // prepareToPlay will be called when the above ScopedRenderStatus goes out of scope
-            pluginInstance->releaseResources();
+            pi->releaseResources();
             isInstancePrepared = false;
 
             jassert (baseClassNeedsInitialising());
@@ -1707,28 +1778,32 @@ bool ExternalPlugin::setBusLayout (juce::AudioChannelSet set, bool isInput, int 
 }
 
 //==============================================================================
-juce::String ExternalPlugin::createPluginInstance (const juce::PluginDescription& description)
+void ExternalPlugin::createPluginInstance (const juce::PluginDescription& description)
 {
-    jassert (! pluginInstance); // This should have already been deleted!
+   #if JUCE_DEBUG
+    jassert (! hasLoadedInstance); // This should have already been deleted!
+   #endif
 
     auto& dm = engine.getDeviceManager();
+    loadError = {};
 
-    juce::String error;
-    pluginInstance = engine.getPluginManager().createPluginInstance (description, dm.getSampleRate(), dm.getBlockSize(), error);
-
-    if (pluginInstance != nullptr)
+    if (auto newInstance = engine.getPluginManager().createPluginInstance (description,
+                                                                           dm.getSampleRate(), dm.getBlockSize(),
+                                                                           loadError))
     {
-        pluginInstance->enableAllBuses();
-        processorChangedManager = std::make_unique<ProcessorChangedManager> (*this);
+        newInstance->enableAllBuses();
+        loadedInstance = LoadedInstance::create (*this, std::move (newInstance));
+        hasLoadedInstance = true;
     }
-
-    return error;
 }
 
 void ExternalPlugin::deletePluginInstance()
 {
-    processorChangedManager.reset();
-    AsyncPluginDeleter::getInstance()->deletePlugin (pluginInstance.release());
+    TRACKTION_ASSERT_MESSAGE_THREAD
+    hasLoadedInstance = false;
+
+    if (auto pi = loadedInstance->releaseInstance())
+        AsyncPluginDeleter::getInstance()->deletePlugin (std::move (pi));
 }
 
 //==============================================================================
@@ -1805,7 +1880,10 @@ void ExternalPlugin::deleteFromParent()
 
 juce::AudioPluginInstance* ExternalPlugin::getAudioPluginInstance() const
 {
-    return pluginInstance.get();
+    if (! hasLoadedInstance)
+        return {};
+
+    return &loadedInstance->getInstance();
 }
 
 void ExternalPlugin::valueTreePropertyChanged (juce::ValueTree& v, const juce::Identifier& id)

--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.h
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.h
@@ -136,12 +136,11 @@ private:
     class ProcessorChangedManager;
     class LoadedInstance;
     std::unique_ptr<LoadedInstance> loadedInstance;
-    std::atomic<bool> hasLoadedInstance { false };
+    std::atomic<bool> hasLoadedInstance { false }, isInstancePrepared { false };
 
     std::unique_ptr<VSTXML> vstXML;
     int latencySamples = 0;
     double latencySeconds = 0;
-    bool isInstancePrepared = false;
 
     double lastSampleRate = 0.0;
     int lastBlockSizeSamples = 0;
@@ -164,7 +163,8 @@ private:
     juce::Array<ExternalAutomatableParameter*> autoParamForParamNumbers;
 
     //==============================================================================
-    void createPluginInstance (const juce::PluginDescription&);
+    void startPluginInstanceCreation (const juce::PluginDescription&);
+    void completePluginInstanceCreation (std::unique_ptr<juce::AudioPluginInstance>);
     void deletePluginInstance();
 
     //==============================================================================
@@ -183,6 +183,9 @@ private:
     std::unique_ptr<juce::PluginDescription> findDescForFileOrID (const juce::String&) const;
 
     void valueTreePropertyChanged (juce::ValueTree&, const juce::Identifier&) override;
+
+    //==============================================================================
+    static bool requiresAsyncInstantiation (Engine&, const juce::PluginDescription&);
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ExternalPlugin)

--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.h
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.h
@@ -36,7 +36,14 @@ public:
     void initialiseFully() override;
     void forceFullReinitialise();
 
+    /// Returns an error message if the plugin failed to load
     juce::String getLoadError();
+
+    /** Returns true if the plugin has started initialising but not completed yet.
+        This happens in the case of some external formats like AUv3. You can use
+        this to show an indicator in your UI.
+    */
+    bool isInitialisingAsync() const;
 
     static const char* xmlTypeName;
 
@@ -136,7 +143,7 @@ private:
     class ProcessorChangedManager;
     class LoadedInstance;
     std::unique_ptr<LoadedInstance> loadedInstance;
-    std::atomic<bool> hasLoadedInstance { false }, isInstancePrepared { false };
+    std::atomic<bool> hasLoadedInstance { false }, isInstancePrepared { false }, isAsyncInitialising { false };
 
     std::unique_ptr<VSTXML> vstXML;
     int latencySamples = 0;


### PR DESCRIPTION
- [x] Add function to ExternalPlugin to find out when a plugin is being created async
- [x] Add a way for the child process scanner to scan for AUv3s on a background thread to pick them up (can't be done on the message thread)
  - [x] Use `AudioFormat::findAllTypesForFile` then filter out the ones that `AudioFormat::requiresUnblockedMessageThreadDuringCreation` and run those on a background thread