### PR TITLE
FR: Updated getClipsLinkInGroup to include clips from Launcher::ClipSlots

### DIFF
--- a/modules/tracktion_engine/model/edit/tracktion_Edit.cpp
+++ b/modules/tracktion_engine/model/edit/tracktion_Edit.cpp
@@ -445,6 +445,13 @@ struct Edit::TreeWatcher   : public juce::ValueTree::Listener
                 return true;
             });
 
+            edit.clipSlotCache.visitItems ([&] (auto cs) {
+                if (auto c = cs->getClip())
+                    if (c->getLinkGroupID().isNotEmpty())
+                        linkedClipsMap[c->getLinkGroupID()].add(c);
+            });
+
+
             linkedClipsMapDirty = false;
         }
 


### PR DESCRIPTION
Before this change any linked Clips added to Launcher's ClipSlots are not updated. 

I'm not sure this behaviour is intentional, but context menu for Waveform 13 indicates it should be possible to have linked clips in ClipSlots. 

<img width="500" alt="Screenshot 2024-10-27 at 1 31 47 PM" src="https://github.com/user-attachments/assets/33325c43-b2f2-4260-a0a1-f2f690fa3c5e">
