### PR TITLE
Fix playing notes notes retriggering when changing clip during first loop in Clip Launcher

### DIFF
--- a/modules/tracktion_engine/playback/graph/tracktion_LoopingMidiNode.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_LoopingMidiNode.cpp
@@ -1028,7 +1028,7 @@ public:
             generator->setTime (0.0);
         }
 
-        return exhausted();
+        return !exhausted();
     }
 
     bool exhausted() override
@@ -1267,7 +1267,10 @@ public:
                                              midiSourceID,
                                              0.0,
                                              isPlaying);
-            shouldCreateMessagesForTime = true;
+            
+            // Only create messages at clip start, otherwise use the existing note state
+            // This prevents notes from retriggering when the step clip content is modified during playback
+            shouldCreateMessagesForTime = blockStartBeatRelativeToClip <= 0.00001_bd;
         }
 
         if (shouldCreateMessagesForTime)


### PR DESCRIPTION
Step to reproduce:

1. Add StepClip to ClipLauncher ClipSlot 0
2. Update notes using GUI

Issue only exists in the first loop if clip is played by ClipLauncher, so I had to modify StepSequencerDemo to include ClipLauncher to debug. 
 

https://github.com/user-attachments/assets/d8d77c67-a263-4452-9baf-5ecb70258e66

https://github.com/user-attachments/assets/5f64b2ce-d13e-4a5c-ac8d-68421edea190

This is updated StepSequencerDemo which uses ClipLuancher
[StepSequencerDemo.h.zip](https://github.com/user-attachments/files/19812721/StepSequencerDemo.h.zip)

