### PR TITLE
Consolidated several messy Plugin bus discovery methods into a single…

### DIFF
--- a/examples/DemoRunner/demos/DistortionEffectDemo.h
+++ b/examples/DemoRunner/demos/DistortionEffectDemo.h
@@ -46,8 +46,7 @@ public:
     void initialise(const PluginInitialisationInfo&) override           {}
     void deinitialise() override                                        {}
 
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override   { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override  { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
 
     void applyToBuffer (const PluginRenderContext& fc) override
     {

--- a/modules/tracktion_engine/playback/graph/tracktion_EditNodeBuilder.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_EditNodeBuilder.cpp
@@ -1277,7 +1277,9 @@ std::unique_ptr<tracktion::graph::Node> createNodeForPlugin (Plugin& plugin, con
     const int incomingChannels = node->getNodeProperties().numberOfChannels;
 
     // Query how many channels the plugin can handle
-    const int pluginInputChannels = plugin.getMainBusInputChannelConfiguration().getNumChannels();
+    const auto busses = plugin.getBusses();
+    const auto mainInputBus = busses.inputs.empty() ? ChannelConfiguration{} : busses.inputs.front();
+    const int pluginInputChannels = mainInputBus.getNumChannels();
 
     // For pass-through plugins (e.g. LevelMeter, VolumeAndPan), the declared input config
     // may be stereo but the plugin can handle any channel count. Use the actual output count
@@ -1324,7 +1326,7 @@ std::unique_ptr<tracktion::graph::Node> createNodeForPlugin (Plugin& plugin, con
     {
         return tracktion::graph::makeNode<ChannelRemappingNode> (std::move (pluginNode),
                                                                  ChannelConfiguration::discreteChannels (incomingChannels),
-                                                                 plugin.getMainBusInputChannelConfiguration());
+                                                                 mainInputBus);
     }
 
     return pluginNode;

--- a/modules/tracktion_engine/playback/graph/tracktion_EditNodeBuilder.test.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_EditNodeBuilder.test.cpp
@@ -683,9 +683,9 @@ TEST_CASE ("Plugin on empty track does not crash with 0-channel buffer")
         expectAudioBuffer (result->buffer, 1, 0.0f, 0.0f);
     };
 
-    // Every internal plugin declared with {} in getMainBusInputChannelConfiguration()
-    // — plus one declared-stereo plugin as a control — exercised in an audio chain
-    // on a track with no clips. None of these should crash or assert.
+    // Every internal plugin declared with {} inputs in getBusses() — plus one
+    // declared-stereo plugin as a control — exercised in an audio chain on a
+    // track with no clips. None of these should crash or assert.
     const juce::StringArray pluginTypeNames
     {
         AuxSendPlugin::xmlTypeName,

--- a/modules/tracktion_engine/playback/graph/tracktion_PluginNode.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_PluginNode.cpp
@@ -70,8 +70,13 @@ tracktion::graph::NodeProperties PluginNode::getNodeProperties()
     // even when the input node reports 0 channels (e.g. unconnected rack plugin).
     // Only truly MIDI-only plugins (no audio in, no audio out) are excluded.
     if (plugin->takesAudioInput() || plugin->producesAudioWhenNoAudioInput())
-        props.numberOfChannels = std::max (props.numberOfChannels,
-                                           plugin->getMainBusInputChannelConfiguration().getNumChannels());
+    {
+        const auto pluginBusses = plugin->getBusses();
+
+        if (! pluginBusses.inputs.empty())
+            props.numberOfChannels = std::max (props.numberOfChannels,
+                                               pluginBusses.inputs.front().getNumChannels());
+    }
 
     if (maxNumChannels > 0)
         props.numberOfChannels = std::min (props.numberOfChannels, maxNumChannels);

--- a/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.h
+++ b/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.h
@@ -52,8 +52,7 @@ public:
     //==============================================================================
     juce::String getSelectableDescription() override;
     int getNumOutputChannelsGivenInputs (int numInputChannels) override;
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override;
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override;
+    BusLayout getBusses() const override;
 
     //==============================================================================
     void initialise (const PluginInitialisationInfo&) override;
@@ -63,7 +62,6 @@ public:
     void resetToDefault();
 
     //==============================================================================
-    bool takesAudioInput() override                  { return true; }
     bool takesMidiInput() override                   { return true; }
     bool producesAudioWhenNoAudioInput() override    { return true; }
     bool canBeAddedToClip() override                 { return true; }

--- a/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindowsBase.cpp
+++ b/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindowsBase.cpp
@@ -78,14 +78,10 @@ int AirWindowsPlugin::getNumOutputChannelsGivenInputs (int)
     return impl->getNumOutputs();
 }
 
-ChannelConfiguration AirWindowsPlugin::getMainBusInputChannelConfiguration() const
+Plugin::BusLayout AirWindowsPlugin::getBusses() const
 {
-    return ChannelConfiguration::canonical (impl->getNumInputs());
-}
-
-ChannelConfiguration AirWindowsPlugin::getMainBusOutputChannelConfiguration() const
-{
-    return ChannelConfiguration::canonical (impl->getNumOutputs());
+    return BusLayout::singleInOut (ChannelConfiguration::canonical (impl->getNumInputs()),
+                                   ChannelConfiguration::canonical (impl->getNumOutputs()));
 }
 
 juce::String AirWindowsPlugin::getSelectableDescription()

--- a/modules/tracktion_engine/plugins/effects/tracktion_Chorus.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_Chorus.h
@@ -25,8 +25,7 @@ public:
     juce::String getShortName (int) override            { return getName(); }
 
     int getNumOutputChannelsGivenInputs (int numInputChannels) override { return juce::jmin (numInputChannels, 2); }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
     void applyToBuffer (const PluginRenderContext&) override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_Compressor.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_Compressor.h
@@ -30,8 +30,7 @@ public:
     juce::String getPluginType() override                               { return xmlTypeName; }
     juce::String getShortName (int) override                            { return TRANS("Comp"); }
     int getNumOutputChannelsGivenInputs (int numInputChannels) override { return juce::jmin (numInputChannels, 2); }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     void getChannelNames (juce::StringArray*, juce::StringArray*) override;
 
     void initialise (const PluginInitialisationInfo&) override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_Delay.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_Delay.h
@@ -65,8 +65,7 @@ public:
     juce::String getSelectableDescription() override    { return TRANS("Delay Plugin"); }
 
     int getNumOutputChannelsGivenInputs (int numInputChannels) override     { return juce::jmin (numInputChannels, 2); }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
     void reset() override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_Equaliser.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_Equaliser.h
@@ -30,8 +30,7 @@ public:
     juce::String getTooltip() override;
 
     int getNumOutputChannelsGivenInputs (int numInputChannels) override { return juce::jmin (numInputChannels, (int) EQ_CHANS); }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
 
     juce::String getSelectableDescription() override    { return TRANS("4-Band Equaliser Plugin"); }
 

--- a/modules/tracktion_engine/plugins/effects/tracktion_FourOscPlugin.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_FourOscPlugin.h
@@ -179,8 +179,7 @@ public:
     juce::String getSelectableDescription() override    { return TRANS("4OSC Plugin"); }
 
     int getNumOutputChannelsGivenInputs (int) override                 { return 2; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
 
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
@@ -192,7 +191,6 @@ public:
 
     //==============================================================================
     bool takesMidiInput() override                      { return true; }
-    bool takesAudioInput() override                     { return false; }
     bool isSynth() override                             { return true; }
     bool producesAudioWhenNoAudioInput() override       { return true; }
     double getTailLength() const override               { return ampRelease->getCurrentValue(); }

--- a/modules/tracktion_engine/plugins/effects/tracktion_ImpulseResponsePlugin.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_ImpulseResponsePlugin.h
@@ -71,9 +71,7 @@ public:
     juce::String getSelectableDescription() override;
 
     /** @internal */
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    /** @internal */
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     /** @internal */
     double getLatencySeconds() override;
     /** @internal */

--- a/modules/tracktion_engine/plugins/effects/tracktion_LatencyPlugin.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_LatencyPlugin.h
@@ -29,8 +29,7 @@ public:
     juce::String getPluginType() override                   { return xmlTypeName; }
     juce::String getSelectableDescription() override        { return getName(); }
 
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
 
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_LowPass.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_LowPass.h
@@ -29,8 +29,7 @@ public:
     void deinitialise() override;
 
     int getNumOutputChannelsGivenInputs (int numInputChannels) override  { return juce::jmin (numInputChannels, 2); }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     void applyToBuffer (const PluginRenderContext&) override;
 
     bool isLowPass() const noexcept                     { return mode.get() != "highpass"; }

--- a/modules/tracktion_engine/plugins/effects/tracktion_MidiModifier.cpp
+++ b/modules/tracktion_engine/plugins/effects/tracktion_MidiModifier.cpp
@@ -41,7 +41,6 @@ void MidiModifierPlugin::deinitialise()                                         
 double MidiModifierPlugin::getLatencySeconds()                                     { return 0.0; }
 int MidiModifierPlugin::getNumOutputChannelsGivenInputs (int)                      { return 0; }
 void MidiModifierPlugin::getChannelNames (juce::StringArray*, juce::StringArray*)  {}
-bool MidiModifierPlugin::takesAudioInput()                                         { return false; }
 bool MidiModifierPlugin::canBeAddedToClip()                                        { return false; }
 
 void MidiModifierPlugin::applyToBuffer (const PluginRenderContext& fc)

--- a/modules/tracktion_engine/plugins/effects/tracktion_MidiModifier.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_MidiModifier.h
@@ -29,14 +29,12 @@ public:
     juce::String getName() const override;
     juce::String getPluginType() override;
     juce::String getShortName (int) override;
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return {}; }
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
     double getLatencySeconds() override;
     int getNumOutputChannelsGivenInputs (int) override;
     void getChannelNames (juce::StringArray*, juce::StringArray*) override;
-    bool takesAudioInput() override;
     bool canBeAddedToClip() override;
 
     void applyToBuffer (const PluginRenderContext&) override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_MidiPatchBay.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_MidiPatchBay.h
@@ -27,13 +27,11 @@ public:
     juce::String getShortName (int) override                                { return TRANS("MIDIPatch"); }
     bool canBeAddedToClip() override                                        { return false; }
     bool canBeAddedToRack() override                                        { return true; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return {}; }
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
     void applyToBuffer (const PluginRenderContext&) override;
     juce::String getSelectableDescription() override                        { return TRANS("MIDI Patch Bay Plugin"); }
-    bool takesAudioInput() override                                         { return false; }
     int getNumOutputChannelsGivenInputs (int) override                      { return 0; }
     void getChannelNames (juce::StringArray*, juce::StringArray*) override  {}
 

--- a/modules/tracktion_engine/plugins/effects/tracktion_PatchBay.cpp
+++ b/modules/tracktion_engine/plugins/effects/tracktion_PatchBay.cpp
@@ -82,11 +82,6 @@ int PatchBayPlugin::getNumOutputChannelsGivenInputs (int numInputChannels)
     return maxChan;
 }
 
-ChannelConfiguration PatchBayPlugin::getMainBusInputChannelConfiguration() const
-{
-    return {};
-}
-
 int PatchBayPlugin::getNumInputChannelsFromChain() const
 {
     auto track = dynamic_cast<AudioTrack*> (getOwnerTrack());
@@ -129,10 +124,10 @@ int PatchBayPlugin::getNumOutputChannelsFromChain() const
 
         if (foundSelf)
         {
-            auto busConfig = p->getMainBusInputChannelConfiguration();
+            auto busses = p->getBusses();
 
-            if (! busConfig.isEmpty())
-                return std::max (numInputChans, busConfig.getNumChannels());
+            if (! busses.inputs.empty() && ! busses.inputs.front().isEmpty())
+                return std::max (numInputChans, busses.inputs.front().getNumChannels());
 
             return numInputChans;
         }

--- a/modules/tracktion_engine/plugins/effects/tracktion_PatchBay.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_PatchBay.h
@@ -46,8 +46,7 @@ public:
     bool canBeDisabled() override                       { return false; }
 
     int getNumOutputChannelsGivenInputs (int numInputChannels) override;
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override;
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
 
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_Phaser.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_Phaser.h
@@ -25,8 +25,7 @@ public:
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
     int getNumOutputChannelsGivenInputs (int numInputChannels) override  { return juce::jmin (numInputChannels, 2); }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     void applyToBuffer (const PluginRenderContext&) override;
     juce::String getSelectableDescription() override;
     void restorePluginStateFromValueTree (const juce::ValueTree&) override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_PitchShift.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_PitchShift.h
@@ -31,8 +31,7 @@ public:
     void deinitialise() override;
     double getLatencySeconds() override;
     int getNumOutputChannelsGivenInputs (int numInputChannels) override  { return juce::jmin (numInputChannels, 2); }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     void applyToBuffer (const PluginRenderContext&) override;
     juce::String getSelectableDescription() override;
     void restorePluginStateFromValueTree (const juce::ValueTree&) override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_Reverb.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_Reverb.h
@@ -27,8 +27,7 @@ public:
     void deinitialise() override;
     void reset() override;
     int getNumOutputChannelsGivenInputs (int numInputChannels) override { return juce::jmin (numInputChannels, 2); }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     void applyToBuffer (const PluginRenderContext&) override;
     juce::String getSelectableDescription() override    { return TRANS("Reverb Plugin"); }
     void restorePluginStateFromValueTree (const juce::ValueTree&) override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.h
@@ -56,8 +56,7 @@ public:
     bool isSynth() override                             { return true; }
 
     int getNumOutputChannelsGivenInputs (int) override                 { return 2; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
     void applyToBuffer (const PluginRenderContext&) override;

--- a/modules/tracktion_engine/plugins/effects/tracktion_ToneGenerator.h
+++ b/modules/tracktion_engine/plugins/effects/tracktion_ToneGenerator.h
@@ -27,8 +27,7 @@ public:
     bool isSynth() override                             { return true; }
 
     int getNumOutputChannelsGivenInputs (int numInputChannels) override { return juce::jmax (1, numInputChannels); }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
     void applyToBuffer (const PluginRenderContext&) override;

--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
@@ -1498,20 +1498,27 @@ int ExternalPlugin::getNumOutputChannelsGivenInputs (int)
     return 1;
 }
 
-ChannelConfiguration ExternalPlugin::getMainBusInputChannelConfiguration() const
+Plugin::BusLayout ExternalPlugin::getBusses() const
 {
+    BusLayout layout;
+
     if (auto pi = getAudioPluginInstance())
-        return ChannelConfiguration::canonical (pi->getMainBusNumInputChannels());
+    {
+        for (int i = 0, n = pi->getBusCount (true); i < n; ++i)
+            if (auto bus = pi->getBus (true, i))
+                layout.inputs.push_back (ChannelConfiguration::canonical (bus->getNumberOfChannels()));
 
-    return ChannelConfiguration::stereo();
-}
+        for (int i = 0, n = pi->getBusCount (false); i < n; ++i)
+            if (auto bus = pi->getBus (false, i))
+                layout.outputs.push_back (ChannelConfiguration::canonical (bus->getNumberOfChannels()));
+    }
+    else
+    {
+        layout.inputs.push_back (ChannelConfiguration::stereo());
+        layout.outputs.push_back (ChannelConfiguration::stereo());
+    }
 
-ChannelConfiguration ExternalPlugin::getMainBusOutputChannelConfiguration() const
-{
-    if (auto pi = getAudioPluginInstance())
-        return ChannelConfiguration::canonical (pi->getMainBusNumOutputChannels());
-
-    return ChannelConfiguration::stereo();
+    return layout;
 }
 
 void ExternalPlugin::getChannelNames (juce::StringArray* ins,
@@ -1723,14 +1730,6 @@ int ExternalPlugin::getTotalNumInputChannels() const
 {
     if (auto pi = getAudioPluginInstance())
         return pi->getTotalNumInputChannels();
-
-    return 0;
-}
-
-int ExternalPlugin::getTotalNumOutputChannels() const
-{
-    if (auto pi = getAudioPluginInstance())
-        return pi->getTotalNumOutputChannels();
 
     return 0;
 }

--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.h
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.h
@@ -91,8 +91,7 @@ public:
 
     bool producesAudioWhenNoAudioInput() override   { return isAutomationNeeded() || isSynth() || ! noTail(); }
     int getNumOutputChannelsGivenInputs (int numInputs) override;
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override;
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override;
+    BusLayout getBusses() const override;
     void getChannelNames (juce::StringArray* ins, juce::StringArray* outs) override;
 
     bool isVST() const noexcept             { return desc.pluginFormatName == "VST"; }
@@ -173,10 +172,6 @@ public:
     /** @deprecated Use getAudioPluginInstance()->getTotalNumInputChannels() instead. */
     [[deprecated ("Use getAudioPluginInstance()->getTotalNumInputChannels() instead")]]
     int getTotalNumInputChannels() const;
-
-    /** @deprecated Use getAudioPluginInstance()->getTotalNumOutputChannels() instead. */
-    [[deprecated ("Use getAudioPluginInstance()->getTotalNumOutputChannels() instead")]]
-    int getTotalNumOutputChannels() const;
 
 private:
     //==============================================================================

--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.test.cpp
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.test.cpp
@@ -118,16 +118,18 @@ TEST_SUITE ("tracktion_engine")
             CHECK_EQ (externalPlugin->getNumOutputChannelsGivenInputs (2), 2);
         }
 
-        SUBCASE ("getMainBusInputChannelConfiguration returns main bus inputs only")
+        SUBCASE ("getBusses() reports all input buses including sidechain")
         {
-            // Should return 2 (main bus stereo), not 3 (total including sidechain)
-            CHECK_EQ (externalPlugin->getMainBusInputChannelConfiguration().getNumChannels(), 2);
+            auto busses = externalPlugin->getBusses();
+            CHECK_EQ (busses.inputs.size(), 2u);                              // main + sidechain
+            CHECK_EQ (busses.inputs.front().getNumChannels(), 2);             // main stereo
         }
 
-        SUBCASE ("getMainBusOutputChannelConfiguration returns main bus outputs only")
+        SUBCASE ("getBusses() reports all output buses including SC monitor")
         {
-            // Should return 2 (main bus stereo), not 3 (total including SC monitor)
-            CHECK_EQ (externalPlugin->getMainBusOutputChannelConfiguration().getNumChannels(), 2);
+            auto busses = externalPlugin->getBusses();
+            CHECK_EQ (busses.outputs.size(), 2u);                             // main + SC monitor
+            CHECK_EQ (busses.outputs.front().getNumChannels(), 2);            // main stereo
         }
 
         SUBCASE ("canSidechain still detects the sidechain bus")

--- a/modules/tracktion_engine/plugins/internal/tracktion_AuxReturn.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_AuxReturn.h
@@ -24,14 +24,12 @@ public:
     juce::String getShortName (int suggestedMaxLength) override;
     juce::String getSelectableDescription() override                        { return TRANS("Aux Return Plugin"); }
     int getNumOutputChannelsGivenInputs (int numInputChannels) override     { return numInputChannels; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
 
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
     void applyToBuffer (const PluginRenderContext&) override;
 
-    bool takesAudioInput() override                  { return true; }
     bool takesMidiInput() override                   { return true; }
     bool producesAudioWhenNoAudioInput() override    { return true; }
     bool canBeAddedToClip() override                 { return false; }

--- a/modules/tracktion_engine/plugins/internal/tracktion_AuxSend.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_AuxSend.h
@@ -39,8 +39,7 @@ public:
     juce::String getPluginType() override           { return xmlTypeName; }
 
     int getNumOutputChannelsGivenInputs (int numInputChannels) override { return numInputChannels; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
     void initialise (const PluginInitialisationInfo&) override;
     void initialiseWithoutStopping (const PluginInitialisationInfo&) override;
     void deinitialise() override;
@@ -48,7 +47,6 @@ public:
 
     juce::String getSelectableDescription() override { return TRANS("Aux Send Plugin"); }
 
-    bool takesAudioInput() override                  { return true; }
     bool canBeAddedToClip() override                 { return false; }
     bool canBeAddedToRack() override                 { return false; }
     bool needsConstantBufferSize() override          { return true; }

--- a/modules/tracktion_engine/plugins/internal/tracktion_ChannelMapperPlugin.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_ChannelMapperPlugin.h
@@ -32,12 +32,10 @@ public:
     juce::String getPluginType() override                                      { return xmlTypeName; }
     juce::String getShortName (int) override                                   { return "ChMap"; }
     juce::String getSelectableDescription() override                           { return TRANS("Channel Mapper Plugin"); }
-    bool takesAudioInput() override                                            { return true; }
     bool takesMidiInput() override                                             { return true; }
     bool canBeAddedToClip() override                                           { return false; }
     bool producesAudioWhenNoAudioInput() override                              { return false; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
 
     int getNumOutputChannelsGivenInputs (int numInputChannels) override;
 

--- a/modules/tracktion_engine/plugins/internal/tracktion_FreezePoint.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_FreezePoint.h
@@ -97,8 +97,7 @@ public:
     void deinitialise() override;
     void applyToBuffer (const PluginRenderContext&) override;
     int getNumOutputChannelsGivenInputs (int numInputChannels) override     { return numInputChannels; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
 
     bool isTrackFrozen() const;
     void freezeTrack (bool shouldBeFrozen);

--- a/modules/tracktion_engine/plugins/internal/tracktion_InsertPlugin.cpp
+++ b/modules/tracktion_engine/plugins/internal/tracktion_InsertPlugin.cpp
@@ -99,7 +99,6 @@ juce::String InsertPlugin::getPluginType()                                   { r
 juce::String InsertPlugin::getShortName (int)                                { return TRANS("Insert"); }
 double InsertPlugin::getLatencySeconds()                                     { return latencySeconds; }
 void InsertPlugin::getChannelNames (juce::StringArray*, juce::StringArray*)  {}
-bool InsertPlugin::takesAudioInput()                                         { return true; }
 bool InsertPlugin::takesMidiInput()                                          { return true; }
 bool InsertPlugin::canBeAddedToClip()                                        { return false; }
 bool InsertPlugin::needsConstantBufferSize()                                 { return true; }

--- a/modules/tracktion_engine/plugins/internal/tracktion_InsertPlugin.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_InsertPlugin.h
@@ -33,12 +33,10 @@ public:
     juce::String getShortName (int) override;
     double getLatencySeconds() override;
     void getChannelNames (juce::StringArray*, juce::StringArray*) override;
-    bool takesAudioInput() override;
     bool takesMidiInput() override;
     bool canBeAddedToClip() override;
     bool needsConstantBufferSize() override;
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
 
     void initialise (const PluginInitialisationInfo&) override;
     void initialiseWithoutStopping (const PluginInitialisationInfo&) override;

--- a/modules/tracktion_engine/plugins/internal/tracktion_LevelMeter.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_LevelMeter.h
@@ -31,8 +31,7 @@ public:
     bool shouldMeasureCpuUsage() const noexcept final   { return false; }
 
     int getNumOutputChannelsGivenInputs (int numInputChannels) override     { return numInputChannels; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
 
     juce::String getSelectableDescription() override                        { return TRANS("Level Meter Plugin"); }
     void initialise (const PluginInitialisationInfo&) override;

--- a/modules/tracktion_engine/plugins/internal/tracktion_RackInstance.cpp
+++ b/modules/tracktion_engine/plugins/internal/tracktion_RackInstance.cpp
@@ -376,14 +376,10 @@ int RackInstance::getNumOutputChannelsGivenInputs (int numInputs)
     return std::max (numInputs, numOutputChannels.get());
 }
 
-ChannelConfiguration RackInstance::getMainBusInputChannelConfiguration() const
+Plugin::BusLayout RackInstance::getBusses() const
 {
-    return ChannelConfiguration::discreteChannels (numInputChannels);
-}
-
-ChannelConfiguration RackInstance::getMainBusOutputChannelConfiguration() const
-{
-    return ChannelConfiguration::discreteChannels (numOutputChannels);
+    return BusLayout::singleInOut (ChannelConfiguration::discreteChannels (numInputChannels),
+                                   ChannelConfiguration::discreteChannels (numOutputChannels));
 }
 
 void RackInstance::trimChannelMappingsToSize (int needed)

--- a/modules/tracktion_engine/plugins/internal/tracktion_RackInstance.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_RackInstance.h
@@ -36,8 +36,7 @@ public:
     bool isSynth() override                             { return true; }
     bool canBeAddedToRack() override                    { return false; }
     int getNumOutputChannelsGivenInputs (int numInputs) override;
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override;
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override;
+    BusLayout getBusses() const override;
     double getLatencySeconds() override;
     bool needsConstantBufferSize() override             { return true; }
 

--- a/modules/tracktion_engine/plugins/internal/tracktion_ReWirePlugin.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_ReWirePlugin.h
@@ -82,8 +82,7 @@ public:
 
     void getChannelNames (juce::StringArray*, juce::StringArray*) override;
     int getNumOutputChannelsGivenInputs (int) override     { return 2; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return ChannelConfiguration::stereo(); }
+    BusLayout getBusses() const override   { return BusLayout::singleStereoInOut(); }
 
     void prepareForNextBlock (TimePosition editTime) override;
     void applyToBuffer (const PluginRenderContext&) override;

--- a/modules/tracktion_engine/plugins/internal/tracktion_TextPlugin.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_TextPlugin.h
@@ -30,8 +30,7 @@ public:
     void deinitialise() override                        {}
     void applyToBuffer (const PluginRenderContext&) override {}
     int getNumOutputChannelsGivenInputs (int numInputChannels) override     { return numInputChannels; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
     bool producesAudioWhenNoAudioInput() override       { return false; }
     juce::String getSelectableDescription() override    { return TRANS("Text Plugin"); }
 

--- a/modules/tracktion_engine/plugins/internal/tracktion_VCA.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_VCA.h
@@ -42,8 +42,7 @@ public:
     bool canBeAddedToFolderTrack()   override           { return true;  }
     bool canBeMoved() override;
 
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return {}; }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singlePassThrough(); }
     void initialise (const PluginInitialisationInfo&) override;
     void deinitialise() override;
     void applyToBuffer (const PluginRenderContext&) override;

--- a/modules/tracktion_engine/plugins/internal/tracktion_VolumeAndPan.h
+++ b/modules/tracktion_engine/plugins/internal/tracktion_VolumeAndPan.h
@@ -61,8 +61,7 @@ public:
     void deinitialise() override;
     void applyToBuffer (const PluginRenderContext&) override;
     int getNumOutputChannelsGivenInputs (int numInputs) override    { return numInputs; }
-    ChannelConfiguration getMainBusInputChannelConfiguration() const override  { return ChannelConfiguration::stereo(); }
-    ChannelConfiguration getMainBusOutputChannelConfiguration() const override { return {}; }
+    BusLayout getBusses() const override   { return BusLayout::singleInOut (ChannelConfiguration::stereo(), ChannelConfiguration::none()); }
 
     void restorePluginStateFromValueTree (const juce::ValueTree&) override;
 

--- a/modules/tracktion_engine/plugins/internal/tracktion_VolumeAndPan.test.cpp
+++ b/modules/tracktion_engine/plugins/internal/tracktion_VolumeAndPan.test.cpp
@@ -28,7 +28,7 @@ TEST_SUITE ("tracktion_engine")
 
         // The plugin declares a minimum of 2 input channels so the graph widens
         // mono upstream via a ChannelRemappingNode.
-        CHECK (vp->getMainBusInputChannelConfiguration().getNumChannels() == 2);
+        CHECK (vp->getBusses().inputs.front().getNumChannels() == 2);
 
         // Output channel count tracks the input for any channel count >= declared min.
         CHECK (vp->getNumOutputChannelsGivenInputs (2) == 2);
@@ -143,7 +143,7 @@ TEST_SUITE ("tracktion_engine")
 
         // Through-rack the plugin should still report pass-through for 4 channels.
         CHECK (volPan->getNumOutputChannelsGivenInputs (4) == 4);
-        CHECK (volPan->getMainBusInputChannelConfiguration().getNumChannels() == 2);
+        CHECK (volPan->getBusses().inputs.front().getNumChannels() == 2);
     }
 }
 

--- a/modules/tracktion_engine/plugins/tracktion_Plugin.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_Plugin.cpp
@@ -155,6 +155,24 @@ int Plugin::getNumOutputChannelsGivenInputs (int)
     return outs.size();
 }
 
+Plugin::BusLayout Plugin::BusLayout::singleInOut (ChannelConfiguration mainInput, ChannelConfiguration mainOutput)
+{
+    BusLayout layout;
+    layout.inputs.push_back (std::move (mainInput));
+    layout.outputs.push_back (std::move (mainOutput));
+    return layout;
+}
+
+Plugin::BusLayout Plugin::BusLayout::singleStereoInOut()
+{
+    return singleInOut (ChannelConfiguration::stereo(), ChannelConfiguration::stereo());
+}
+
+Plugin::BusLayout Plugin::BusLayout::singlePassThrough()
+{
+    return singleInOut (ChannelConfiguration::none(), ChannelConfiguration::none());
+}
+
 int Plugin::getNumWires() const
 {
     if (sidechainWireList != nullptr)

--- a/modules/tracktion_engine/plugins/tracktion_Plugin.h
+++ b/modules/tracktion_engine/plugins/tracktion_Plugin.h
@@ -301,19 +301,56 @@ public:
         output channels. Either pointer may be nullptr if not needed. */
     virtual void getChannelNames (juce::StringArray* ins, juce::StringArray* outs);
 
-    /** Returns the main bus input channel configuration for this plugin.
-        Return {} for no minimum (pass-through plugins).
-        Return ChannelConfiguration::stereo() for plugins that genuinely need stereo.
-    */
-    virtual ChannelConfiguration getMainBusInputChannelConfiguration() const = 0;
+    /** Describes the full input/output bus topology of a plugin.
+        The first entry in each list (if present) is the main bus; additional entries
+        represent sidechain, aux, or multi-out buses.
 
-    /** Returns the main bus output channel configuration for this plugin.
-        Return {} for no minimum (pass-through plugins).
-        Return ChannelConfiguration::stereo() for synths that always produce stereo.
-    */
-    virtual ChannelConfiguration getMainBusOutputChannelConfiguration() const = 0;
+        Empty `inputs`/`outputs` means the plugin has no audio bus in that direction (a
+        MIDI-only plugin, or a pure synth with no audio input, etc.). A bus that exists
+        but imposes no channel-count requirement — i.e. pass-through — uses
+        `ChannelConfiguration::none()`.
 
-    virtual bool takesAudioInput()                      { return ! isSynth(); }
+            return {};                                                                       // MIDI plugin (no audio buses either side)
+            return BusLayout::singleStereoInOut();  // typical stereo effect
+            return BusLayout::singleInOut (ChannelConfiguration::stereo(), ChannelConfiguration::none());    // stereo in, pass-through out
+    */
+    struct BusLayout
+    {
+        choc::SmallVector<ChannelConfiguration, 4> inputs;
+        choc::SmallVector<ChannelConfiguration, 4> outputs;
+
+        /** Returns a layout with one main input bus and one main output bus. Use this
+            for the common single-in-single-out case. Multi-bus plugins (sidechain,
+            aux, multi-out) should construct a BusLayout and populate `inputs`/`outputs`
+            directly. */
+        static BusLayout singleInOut (ChannelConfiguration mainInput, ChannelConfiguration mainOutput);
+
+        /** Shorthand for `singleInOut (ChannelConfiguration::stereo(), ChannelConfiguration::stereo())`.
+            Use for plugins that always work in stereo (the vast majority of stereo effects). */
+        static BusLayout singleStereoInOut();
+
+        /** Shorthand for `singleInOut (ChannelConfiguration::none(), ChannelConfiguration::none())`.
+            Use for plugins that have one audio bus each side but impose no channel-count
+            requirement — e.g. VCA, LevelMeter, ChannelMapper, AuxSend/AuxReturn, Insert. */
+        static BusLayout singlePassThrough();
+    };
+
+    /** Returns the full input/output bus layout of this plugin.
+
+        Every concrete plugin must declare its bus topology here. Multi-out plugins
+        (e.g. ExternalPlugin hosting a VST3 with multiple output buses) report each
+        output bus as a separate entry in the returned layout's `outputs` list; the
+        first entry is the main bus.
+
+        Consumers that only need the main bus can use e.g. `getBusses().outputs.front()`.
+    */
+    virtual BusLayout getBusses() const = 0;
+
+    /** Returns true if this plugin should be fed audio from upstream in the chain.
+        The default derives from the bus layout: a non-synth that declares at least
+        one audio input bus takes audio. Synths that also accept audio input (e.g.
+        for wet/dry mix) should override to return true explicitly. */
+    virtual bool takesAudioInput()                      { return ! isSynth() && ! getBusses().inputs.empty(); }
     virtual bool takesMidiInput()                       { return false; }
     virtual bool isSynth()                              { return false; }
 

--- a/modules/tracktion_engine/utilities/tracktion_ChannelConfiguration.h
+++ b/modules/tracktion_engine/utilities/tracktion_ChannelConfiguration.h
@@ -71,6 +71,13 @@ public:
     //==============================================================================
     // Factory methods for common configurations
 
+    /// Creates an empty configuration — a bus that imposes no channel-count
+    /// requirement. Use this for buses that should pass audio through at whatever
+    /// channel count the graph happens to be running at (e.g. VolumeAndPan's
+    /// output, LevelMeter, VCA). Equivalent to a default-constructed instance,
+    /// but more self-documenting at the call site.
+    static ChannelConfiguration none()                      { return {}; }
+
     /// Creates a mono configuration with a single channel.
     static ChannelConfiguration mono (int deviceChannelIndex = 0);
 


### PR DESCRIPTION
… getBusses() method. This simplifies the subclasses and also lets us distinguish "no busses" from "1 empty bus"