### PR TITLE
Audio: Added a discrete channel fallback when creating time-stretched…

### DIFF
--- a/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.cpp
@@ -152,7 +152,13 @@ private:
         if (sourceInfo.metadata.getValue ("MetaDataSource", "None") == "AIFF")
             sourceInfo.metadata.clear();
 
-        AudioFileWriter writer (tempFile, engine.getAudioFileFormatManager().getWavFormat(),
+        auto wavFormat = engine.getAudioFileFormatManager().getWavFormat();
+
+        // If the specific format is supported, fallback to a discrete layout for proxies which is always supported
+        if (! wavFormat->isChannelLayoutSupported (sourceInfo.channelLayout))
+            sourceInfo.channelLayout = juce::AudioChannelSet::discreteChannels (sourceInfo.channelLayout.size());
+
+        AudioFileWriter writer (tempFile, wavFormat,
                                 sourceInfo.numChannels, sourceInfo.sampleRate,
                                 std::max (16, sourceInfo.bitsPerSample),
                                 sourceInfo.metadata, 0,


### PR DESCRIPTION
… proxies for greater than 5.1 channels which aren't compatible with juce::WavAudioFormat