### PR TITLE
Fixed crash when MIDI arrives during ExternalController destruction

### DIFF
--- a/modules/tracktion_engine/control_surfaces/tracktion_ExternalController.cpp
+++ b/modules/tracktion_engine/control_surfaces/tracktion_ExternalController.cpp
@@ -75,9 +75,6 @@ ExternalController::~ExternalController()
         for (auto p : af->getAutomatableParameters())
             p->removeListener (this);
 
-    getControlSurface().shutDownDevice();
-    controlSurface = nullptr;
-
     auto& dm = engine.getDeviceManager();
     dm.removeChangeListener (this);
 
@@ -85,6 +82,9 @@ ExternalController::~ExternalController()
         if (auto min = dynamic_cast<PhysicalMidiInputDevice*> (d.get()))
             if (min->isEnabled())
                 min->removeExternalController (this);
+
+    getControlSurface().shutDownDevice();
+    controlSurface = nullptr;
 
     if (lastRegisteredSelectable != nullptr)
     {


### PR DESCRIPTION
## Summary
- Reorder `ExternalController::~ExternalController()` to unregister from MIDI input devices **before** destroying the `ControlSurface`
- The previous order destroyed the `ControlSurface` (nulling the `unique_ptr`) first, then unregistered from MIDI devices — leaving a window where the MIDI thread could call `wantsMessage` on an already-destroyed `ControlSurface`
- Crash manifested as null dereference in `JavascriptEngine::getRootObject` called from `JSControllerInt::canInvoke` on the MIDI input thread

## Test plan
- [ ] Connect a MIDI controller using a JS controller script
- [ ] Remove/delete the controller while MIDI is actively being received
- [ ] Verify no crash on shutdown with active MIDI input

🤖 Generated with [Claude Code](https://claude.com/claude-code)