### PR TITLE
ARA: Overhauled hosting lifecycle, region management and notifications

### DIFF
--- a/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.cpp
@@ -1182,6 +1182,18 @@ bool AudioClipBase::isUsingARA() const
     return TimeStretcher::isARA (timeStretchMode);
 }
 
+void AudioClipBase::selectionStatusChanged (bool isNowSelected)
+{
+    Clip::selectionStatusChanged (isNowSelected);
+
+   #if TRACKTION_ENABLE_ARA
+    // Tell the ARA plugin's editor views about the new selection so their UI
+    // can follow the arrangement
+    if (isNowSelected && araProxy != nullptr && araProxy->isValid())
+        araProxy->notifyViewSelection();
+   #endif
+}
+
 TimeDuration AudioClipBase::getHead() const  { return araProxy != nullptr ? araProxy->getHead() : TimeDuration(); }
 TimeDuration AudioClipBase::getTail() const  { return araProxy != nullptr ? araProxy->getTail() : TimeDuration(); }
 

--- a/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.h
+++ b/modules/tracktion_engine/model/clips/tracktion_AudioClipBase.h
@@ -601,6 +601,9 @@ public:
     /** Returns true if this clip is using an ARA plugin. */
     bool isUsingARA() const;
 
+    /** @internal Keeps the ARA plugin's editor view following the arrangement selection. */
+    void selectionStatusChanged (bool isNowSelected) override;
+
     TimeDuration getHead() const override;
     TimeDuration getTail() const override;
 

--- a/modules/tracktion_engine/plugins/ARA/tracktion_ARAFileReader.cpp
+++ b/modules/tracktion_engine/plugins/ARA/tracktion_ARAFileReader.cpp
@@ -426,6 +426,11 @@ struct ARAClipPlayer  : private Selectable::Listener
             playbackRegionAndSource->setViewSelection();
     }
 
+    int getNumPlaybackRegions() const
+    {
+        return playbackRegionAndSource != nullptr ? (int) playbackRegionAndSource->playbackRegions.size() : 0;
+    }
+
     //==============================================================================
     void startProcessing()  { TRACKTION_ASSERT_MESSAGE_THREAD if (playbackRegionAndSource != nullptr) playbackRegionAndSource->enable(); }
     void stopProcessing()   { TRACKTION_ASSERT_MESSAGE_THREAD if (playbackRegionAndSource != nullptr) playbackRegionAndSource->disable(); }
@@ -666,21 +671,12 @@ private:
                 if (playbackRegionAndSource != nullptr
                      && playbackRegionAndSource->hasPlaybackRegions())
                 {
-                    // Check if looping state requires a full region rebuild
-                    bool isLooping = clip.isLooping();
-                    auto regionCount = playbackRegionAndSource->playbackRegions.size();
-                    bool needsRebuild = (isLooping && regionCount <= 1)
-                                      || (! isLooping && regionCount > 1);
-
-                    if (isLooping)
-                    {
-                        auto loopLen = clip.getLoopLength().inSeconds();
-                        auto clipLen = clip.getPosition().getLength().inSeconds();
-                        size_t expectedCount = (loopLen > 0.0) ? (size_t) std::ceil (clipLen / loopLen) : 1;
-                        needsRebuild = needsRebuild || (regionCount != expectedCount);
-                    }
-
-                    if (needsRebuild)
+                    // Only rebuild when the region layout (loop mode / repeat count) no
+                    // longer matches the clip - a rebuild is a remove-all/re-add the
+                    // plugin can see and hear, so it mustn't happen for no-op updates
+                    if (! playbackRegionAndSource->playbackRegionLayoutMatches (clip.isLooping(),
+                                                                                clip.getPosition().getLength().inSeconds(),
+                                                                                clip.getLoopLength().inSeconds()))
                     {
                         const ScopedDocumentEditor sde (*this, true);
 
@@ -815,11 +811,21 @@ ARAFileReader::~ARAFileReader()
 //==============================================================================
 void ARAFileReader::showPluginWindow()
 {
-    if (player != nullptr)
-        player->setViewSelection();
+    notifyViewSelection();
 
     if (auto p = getPlugin())
         p->showWindowExplicitly();
+}
+
+void ARAFileReader::notifyViewSelection()
+{
+    if (player != nullptr)
+        player->setViewSelection();
+}
+
+int ARAFileReader::getNumPlaybackRegions() const
+{
+    return player != nullptr ? player->getNumPlaybackRegions() : 0;
 }
 
 void ARAFileReader::hidePluginWindow()
@@ -1270,21 +1276,30 @@ void ARADocumentHolder::flushStateToValueTree()
 
     if (pimpl != nullptr)
     {
-        // Remove old per-plugin children
-        for (int i = lastState.getNumChildren(); --i >= 0;)
-            if (lastState.getChild (i).hasType (IDs::ARAPLUGIN))
-                lastState.removeChild (i, nullptr);
-
-        // Remove old-format data property
-        lastState.removeProperty ("data", nullptr);
-
-        // Save each document under its own ARAPLUGIN child
+        // Save each document under its own ARAPLUGIN child. NB: never replace a
+        // previously-saved archive with nothing - if a document produced no data
+        // (the plugin failed to store, or no documents were loaded, e.g. an edit
+        // saved by an export job that doesn't load plugins), keep whatever was
+        // saved before rather than silently wiping the user's ARA edits
         for (auto& [key, doc] : pimpl->araDocuments)
         {
             juce::ValueTree pluginState (IDs::ARAPLUGIN);
             pluginState.setProperty (IDs::id, key, nullptr);
             doc->flushStateToValueTree (pluginState);
+
+            if (! pluginState.hasProperty ("data"))
+                continue;
+
+            auto existing = lastState.getChildWithProperty (IDs::id, key);
+
+            if (existing.isValid())
+                lastState.removeChild (existing, nullptr);
+
             lastState.addChild (pluginState, -1, nullptr);
+
+            // This document is now saved per-plugin, so the old-format
+            // whole-document property is stale
+            lastState.removeProperty ("data", nullptr);
         }
     }
 }
@@ -1293,6 +1308,10 @@ void ARADocumentHolder::flushStateToValueTree()
 struct ARAPluginBinding::Impl
 {
     std::unique_ptr<ARAClipPlayer::ARAInstance> instance;
+
+    // The document outlives all bindings: it's owned by the Edit's ARADocumentHolder,
+    // and bindings are owned by UI that's torn down before the Edit
+    ARAClipPlayer::ARADocument* document = nullptr;
 };
 
 ARAPluginBinding::ARAPluginBinding (std::unique_ptr<Impl> implToUse)
@@ -1300,32 +1319,64 @@ ARAPluginBinding::ARAPluginBinding (std::unique_ptr<Impl> implToUse)
 {
 }
 
-ARAPluginBinding::~ARAPluginBinding() = default;
+ARAPluginBinding::~ARAPluginBinding()
+{
+    if (impl != nullptr && impl->document != nullptr && impl->instance != nullptr)
+    {
+        auto& views = impl->document->additionalEditorViews;
+        views.erase (std::remove (views.begin(), views.end(), impl->instance->extensionInstance), views.end());
+    }
+}
 
-std::unique_ptr<ARAPluginBinding> ARADocumentHolder::bindPluginToDocument (ExternalPlugin& plugin,
-                                                                          const juce::PluginDescription& desc)
+bool ARADocumentHolder::bindPluginToDocument (ExternalPlugin& plugin,
+                                              const juce::PluginDescription& desc)
 {
     TRACKTION_ASSERT_MESSAGE_THREAD
 
     if (! desc.hasARAExtension)
-        return {};
+        return false;
+
+    // A plugin returned from the PluginCache may already be bound from an earlier
+    // panel session - the bind lasts for the instance's lifetime (destroying the
+    // binding wrapper doesn't end it), and binding twice is invalid, so keep it
+    if (plugin.isBoundToARADocument())
+        return true;
 
     auto doc = getPimpl()->getOrCreateDocument (desc);
 
     if (doc == nullptr)
-        return {};
+        return false;
 
     auto& pluginFactory = ARAClipPlayer::ARAPluginFactory::getInstance (edit.engine, desc);
 
+    //==============================================================================
+    // TODO QA16472: per the ARA spec / vendor guidance, the browser/panel instance
+    // should be ASSIGNED only the editor roles, i.e. pass
+    //     kARAEditorRendererRole | kARAEditorViewRole
+    // as the third argument here, so the plugin doesn't preview its accompaniment
+    // while the DAW is playing
+    //==============================================================================
     std::unique_ptr<ARAClipPlayer::ARAInstance> instance (pluginFactory.createInstance (plugin, doc->dcRef));
 
     if (instance == nullptr)
-        return {};
+        return false;
+
+    // Its VST3 instance is ARA-bound, so it must be destroyed synchronously
+    // (before the document controller) rather than via the async deleter
+    plugin.setDeletesPluginInstanceSynchronously (true);
+
+    // Register the editor view so arrangement selection changes reach it too
+    doc->additionalEditorViews.push_back (instance->extensionInstance);
 
     auto impl = std::make_unique<ARAPluginBinding::Impl>();
     impl->instance = std::move (instance);
+    impl->document = doc;
 
-    return std::unique_ptr<ARAPluginBinding> (new ARAPluginBinding (std::move (impl)));
+    // The plugin owns the binding, so a strong ref back to it would be a refcount cycle
+    impl->instance->plugin = nullptr;
+
+    plugin.setARADocumentBinding (std::unique_ptr<ARAPluginBinding> (new ARAPluginBinding (std::move (impl))));
+    return true;
 }
 
 ARAClipPlayer::ARADocument* ARAClipPlayer::getDocument() const
@@ -1437,6 +1488,8 @@ void ARAFileReader::cleanUpOnShutdown()                        {}
 ExternalPlugin* ARAFileReader::getPlugin()                     { return {}; }
 void ARAFileReader::showPluginWindow()                         {}
 void ARAFileReader::hidePluginWindow()                         {}
+void ARAFileReader::notifyViewSelection()                      {}
+int ARAFileReader::getNumPlaybackRegions() const               { return 0; }
 bool ARAFileReader::isAnalysingContent()                       { return false; }
 juce::MidiMessageSequence ARAFileReader::getAnalysedMIDISequence()   { return {}; }
 void ARAFileReader::sourceClipChanged()                        {}
@@ -1460,7 +1513,7 @@ void ARADocumentHolder::flushStateToValueTree() {}
 struct ARAPluginBinding::Impl {};
 ARAPluginBinding::ARAPluginBinding (std::unique_ptr<Impl> implToUse) : impl (std::move (implToUse)) {}
 ARAPluginBinding::~ARAPluginBinding() = default;
-std::unique_ptr<ARAPluginBinding> ARADocumentHolder::bindPluginToDocument (ExternalPlugin&, const juce::PluginDescription&)   { return {}; }
+bool ARADocumentHolder::bindPluginToDocument (ExternalPlugin&, const juce::PluginDescription&)   { return false; }
 
 } // namespace tracktion::inline engine
 

--- a/modules/tracktion_engine/plugins/ARA/tracktion_ARAFileReader.h
+++ b/modules/tracktion_engine/plugins/ARA/tracktion_ARAFileReader.h
@@ -68,6 +68,16 @@ public:
     void showPluginWindow();
     void hidePluginWindow();
 
+    /** Sends the clip's playback regions and region sequence as the current view
+        selection to every editor view bound to the document (the clip's own
+        instance and e.g. the browser panel instance). Call when the arrangement
+        selection changes so the plugin's UI can follow it. */
+    void notifyViewSelection();
+
+    /** Returns the number of ARA playback regions currently created for the clip
+        (one per loop repeat for looping clips). */
+    int getNumPlaybackRegions() const;
+
     bool isAnalysingContent();
     juce::MidiMessageSequence getAnalysedMIDISequence();
 
@@ -143,9 +153,11 @@ ARAIXMLResult detectARAFromIXMLChunks (Engine&, const juce::File& sourceFile);
 
 
 //==============================================================================
-/** Owns an ARA document-controller binding created by
-    ARADocumentHolder::bindPluginToDocument. Destroying it releases the binding,
-    taking the plugin out of ARA mode. */
+/** RAII wrapper for an ARA document-controller binding created by
+    ARADocumentHolder::bindPluginToDocument, owned by the bound ExternalPlugin
+    (see ExternalPlugin::setARADocumentBinding). It's destroyed - unregistering
+    from the ARA document - just before the plugin's instance is deleted, which
+    is when the bind itself actually ends. */
 class ARAPluginBinding
 {
 public:
@@ -173,9 +185,13 @@ struct ARADocumentHolder
         controller for the given description (lazily creating the document), putting the
         plugin into ARA mode. No audio source, playback region or musical context is created.
 
-        Returns null if the plugin isn't ARA-capable, its instance isn't loaded yet, or the
-        binding fails. The returned object owns the binding for as long as it's kept alive. */
-    std::unique_ptr<ARAPluginBinding> bindPluginToDocument (ExternalPlugin&, const juce::PluginDescription&);
+        The plugin takes ownership of the binding (ExternalPlugin::setARADocumentBinding),
+        which lasts for the lifetime of its loaded instance - if the plugin is already
+        bound (e.g. it came back from the PluginCache), the existing binding is kept.
+
+        Returns false if the plugin isn't ARA-capable, its instance isn't loaded yet, or
+        the binding fails. */
+    bool bindPluginToDocument (ExternalPlugin&, const juce::PluginDescription&);
 
     struct Pimpl;
     Pimpl* getPimpl();

--- a/modules/tracktion_engine/plugins/ARA/tracktion_ARAPluginFactory.h
+++ b/modules/tracktion_engine/plugins/ARA/tracktion_ARAPluginFactory.h
@@ -141,6 +141,12 @@ public:
         return cache;
     }
 
+    /** The full role set used for clip player instances, which render playback audio
+        as well as hosting the editor. */
+    static constexpr ARAPlugInInstanceRoleFlags allInstanceRoles = kARAPlaybackRendererRole
+                                                                    | kARAEditorRendererRole
+                                                                    | kARAEditorViewRole;
+
     ExternalPlugin::Ptr createPlugin (Edit& ed)
     {
         if (plugin != nullptr)
@@ -149,7 +155,12 @@ public:
             ExternalPlugin::Ptr p = new ExternalPlugin (PluginCreationInfo (ed, newState, true));
 
             if (p->getAudioPluginInstance() != nullptr)
+            {
+                // ARA-bound instances must be destroyed before their document
+                // controller, so they can't go through the shared async deleter
+                p->setDeletesPluginInstanceSynchronously (true);
                 return p;
+            }
         }
 
         return {};
@@ -161,12 +172,16 @@ public:
         ExternalPlugin::Ptr p = new ExternalPlugin (PluginCreationInfo (ed, newState, true));
 
         if (p->getAudioPluginInstance() != nullptr)
+        {
+            p->setDeletesPluginInstanceSynchronously (true);
             return p;
+        }
 
         return {};
     }
 
-    ARAInstance* createInstance (ExternalPlugin& p, ARADocumentControllerRef dcRef)
+    ARAInstance* createInstance (ExternalPlugin& p, ARADocumentControllerRef dcRef,
+                                 ARAPlugInInstanceRoleFlags roles = allInstanceRoles)
     {
         TRACKTION_ASSERT_MESSAGE_THREAD
         jassert (plugin != nullptr);
@@ -176,7 +191,7 @@ public:
         w->factory = factory;
         w->extensionInstance = nullptr;
 
-        if (! setExtensionInstance (*w, dcRef))
+        if (! setExtensionInstance (*w, dcRef, roles))
             w = nullptr;
 
         return w.release();
@@ -186,8 +201,10 @@ public:
 
     ~ARAPluginFactory()
     {
-        initGuard.reset();
+        // The dummy instance must go before uninitializeARA - the spec requires all
+        // of a module's plugin instances to be destroyed before ARA is uninitialised
         plugin = nullptr;
+        initGuard.reset();
     }
 
 private:
@@ -287,7 +304,7 @@ private:
             factory = nullptr;
     }
 
-    bool setExtensionInstance (ARAInstance& w, ARADocumentControllerRef dcRef)
+    bool setExtensionInstance (ARAInstance& w, ARADocumentControllerRef dcRef, ARAPlugInInstanceRoleFlags roles)
     {
         TRACKTION_ASSERT_MESSAGE_THREAD
         CRASH_TRACER
@@ -298,7 +315,7 @@ private:
         auto type = plugin->getPluginDescription().pluginFormatName;
 
         if (type == "VST3")
-            return setExtensionInstanceVST3 (w, dcRef);
+            return setExtensionInstanceVST3 (w, dcRef, roles);
 
         return false;
     }
@@ -326,17 +343,18 @@ private:
         return {};
     }
 
-    bool setExtensionInstanceVST3 (ARAInstance& w, ARADocumentControllerRef dcRef)
+    bool setExtensionInstanceVST3 (ARAInstance& w, ARADocumentControllerRef dcRef, ARAPlugInInstanceRoleFlags roles)
     {
         if (auto p = w.plugin->getAudioPluginInstance())
         {
             auto vst3EntryPoint2 = getVST3EntryPoint<IPlugInEntryPoint2> (*p);
 
+            // knownRoles must always declare every role this host implements - a role
+            // missing from knownRoles makes the plugin fall back to handling it
+            // internally. Only assignedRoles is narrowed (e.g. editor-only for the
+            // browser/panel instance, so it doesn't act as a playback renderer).
             if (vst3EntryPoint2 != nullptr)
-            {
-                ARAPlugInInstanceRoleFlags roles = kARAPlaybackRendererRole | kARAEditorRendererRole | kARAEditorViewRole;
-                w.extensionInstance = vst3EntryPoint2->bindToDocumentControllerWithRoles (dcRef, roles, roles);
-            }
+                w.extensionInstance = vst3EntryPoint2->bindToDocumentControllerWithRoles (dcRef, allInstanceRoles, roles);
         }
 
         return w.extensionInstance != nullptr;

--- a/modules/tracktion_engine/plugins/ARA/tracktion_ARAWrapperInterfaces.h
+++ b/modules/tracktion_engine/plugins/ARA/tracktion_ARAWrapperInterfaces.h
@@ -69,8 +69,10 @@ public:
             musicalContext = nullptr;
         }
 
-        dci->destroyDocumentController (dcRef);
+        // The spec requires bound plugin instances to be destroyed before the
+        // document controller they're bound to
         wrapper = nullptr;
+        dci->destroyDocumentController (dcRef);
     }
 
     bool canEdit (bool dontCheckMusicalContext) const
@@ -506,6 +508,12 @@ public:
     std::unique_ptr<juce::MemoryBlock> lastArchiveState;
     juce::String lastArchiveDocumentArchiveID;
 
+    // Editor-view-only instances bound to this document besides the clip players
+    // (e.g. the plugin panel's browser instance) - view selection notifications
+    // are fanned out to these as well. Registered/unregistered by
+    // ARADocumentHolder::bindPluginToDocument / ~ARAPluginBinding.
+    std::vector<const ARAPlugInExtensionInstance*> additionalEditorViews;
+
 private:
     std::unique_ptr<ARAInstance> wrapper;
     std::unique_ptr<ARADocumentControllerHostInstance> hostInstance;
@@ -829,6 +837,22 @@ private:
         virtual const void* getDataForEvent (int index) const = 0;
     };
 
+    /** Removes entries whose position doesn't strictly increase over the previous
+        entry, keeping the later entry. Plug-ins validate that content events are
+        strictly ordered and can assert or abort on duplicates, which zero-length
+        progression items or rounding after tempo changes can otherwise produce. */
+    template <typename ContentType, typename GetPosition>
+    static void removeNonIncreasingPositions (juce::Array<ContentType>& items, GetPosition&& getPosition)
+    {
+        for (int i = 1; i < items.size();)
+        {
+            if (getPosition (items.getReference (i)) <= getPosition (items.getReference (i - 1)))
+                items.remove (i - 1);
+            else
+                ++i;
+        }
+    }
+
     template <typename ContentType>
     struct TimeEventReaderHelper : public TimeEventReaderBase
     {
@@ -884,6 +908,8 @@ private:
                                                 beatsToQuarters (ed, timeSig->getStartBeat()) };
                 items.add (item);
             }
+
+            removeNonIncreasingPositions (items, [] (const ARAContentBarSignature& i) { return i.position; });
         }
 
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (TimeSigReader)
@@ -934,6 +960,8 @@ private:
                 extrapolatedTempoEntry.quarterPosition += ed.tempoSequence.getBpmAt (TimePosition::fromSeconds (items.getLast().timePosition));
                 items.add (extrapolatedTempoEntry);
             }
+
+            removeNonIncreasingPositions (items, [] (const ARAContentTempoEntry& i) { return i.quarterPosition; });
         }
 
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (TempoReader)
@@ -1021,6 +1049,10 @@ private:
                 items.add (item);
             }
 
+            // Zero-length progression items produce two chords at the same position,
+            // which ARA plugins reject - keep the later (audible) one
+            removeNonIncreasingPositions (items, [] (const ARAContentChord& i) { return i.position; });
+
             // make sure there is always at least a trailing "no chord"
             if (items.isEmpty())
             {
@@ -1078,6 +1110,8 @@ private:
                 item.position = beatsToQuarters (ed, pitchSetting->getStartBeatNumber());
                 items.add (item);
             }
+
+            removeNonIncreasingPositions (items, [] (const ARAContentKeySignature& i) { return i.position; });
         }
 
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (KeySignatureReader)
@@ -1165,8 +1199,22 @@ public:
         CRASH_TRACER
         TRACKTION_ASSERT_MESSAGE_THREAD
 
+        // The cached file info can be stale or missing at this point (e.g. a freshly
+        // unpacked project archive) - re-parse it rather than describing the source
+        // to the plugin with a zero sample rate, which is invalid per the ARA spec
+        if (audioFile.getInfo().sampleRate <= 0.0)
+            audioFile.engine->getAudioFileManager().forceFileUpdate (audioFile);
+
         updateAudioSourceProperties();
         auto audioSourceProperties = getAudioSourceProperties();
+
+        if (audioSourceProperties.sampleRate <= 0.0 || audioSourceProperties.sampleCount <= 0)
+        {
+            TRACKTION_LOG_ERROR ("ARA: not creating an audio source for an unreadable file: "
+                                 + audioFile.getFile().getFullPathName());
+            return;
+        }
+
         audioSourceRef = doc.dci->createAudioSource (doc.dcRef, toHostRef (this), &audioSourceProperties);
     }
 
@@ -1335,7 +1383,7 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioModificationWrapper)
 };
 
-class RegionSequenceWrapper
+class RegionSequenceWrapper  : private SelectableListener
 {
 public:
     RegionSequenceWrapper (ARADocument& d, Track* t) : doc (d), track (t)
@@ -1346,10 +1394,18 @@ public:
         updateRegionSequenceProperties();
         auto regionSequenceProperties = getRegionSequenceProperties();
         regionSequenceRef = doc.dci->createRegionSequence (doc.dcRef, toHostRef (&doc.edit), &regionSequenceProperties);
+
+        // A track rename/recolour with no accompanying clip change must still
+        // reach the plugin, so watch the track itself
+        if (track != nullptr)
+            track->addSelectableListener (this);
     }
 
     ~RegionSequenceWrapper()
     {
+        if (track != nullptr)
+            track->removeSelectableListener (this);
+
         if (regionSequenceRef != nullptr)
             doc.dci->destroyRegionSequence (doc.dcRef, regionSequenceRef);
     }
@@ -1382,6 +1438,34 @@ public:
     Track* track;
 
 private:
+    void selectableObjectChanged (Selectable*) override
+    {
+        // Selectable changes arrive asynchronously on the message thread, so it's
+        // safe to open an editing cycle here. Tracks change for many reasons besides
+        // the properties a region sequence mirrors, so skip no-op notifications.
+        if (track == nullptr || regionSequenceRef == nullptr)
+            return;
+
+        auto trackColour = track->getColour();
+        const ARAColor newColour { trackColour.getFloatRed(), trackColour.getFloatGreen(), trackColour.getFloatBlue() };
+
+        if (name == track->getName()
+             && orderIndex == track->getIndexInEditTrackList()
+             && colour.r == newColour.r && colour.g == newColour.g && colour.b == newColour.b)
+            return;
+
+        if (doc.canEdit (false))
+        {
+            const ARADocument::ScopedEdit scope (doc, false);
+            updateProperties();
+        }
+    }
+
+    void selectableObjectAboutToBeDeleted (Selectable*) override
+    {
+        track = nullptr;
+    }
+
     void updateRegionSequenceProperties()
     {
         name = track->getName();
@@ -1637,26 +1721,70 @@ public:
             audioSource->releaseAccess();
     }
 
+    /** Sends the current selection (all of this clip's playback regions plus its
+        region sequence) to every editor view on the document: the clip's own
+        instance and any additional bound editor views (e.g. the browser panel). */
     void setViewSelection()
     {
-        if (pluginInstance.editorViewInterface != nullptr && ! playbackRegions.empty())
-        {
-            ARAViewSelection selection;
+        // Don't notify while an archive is being restored
+        if (! araDoc.canEdit (true))
+            return;
 
-            ARAPlaybackRegionRef refs[1];
-            refs[0] = playbackRegions[0]->playbackRegionRef;
+        std::vector<ARAPlaybackRegionRef> regionRefs;
 
-            selection.structSize = sizeof (selection);
+        for (auto& pr : playbackRegions)
+            if (pr->playbackRegionRef != nullptr)
+                regionRefs.push_back (pr->playbackRegionRef);
 
-            selection.playbackRegionRefsCount = 1;
-            selection.playbackRegionRefs = refs;
+        if (regionRefs.empty())
+            return;
 
-            selection.regionSequenceRefsCount = 0;
-            selection.regionSequenceRefs = nullptr;
-            selection.timeRange = nullptr;
+        ARARegionSequenceRef sequenceRef = nullptr;
 
-            pluginInstance.editorViewInterface->notifySelection (pluginInstance.editorViewRef, &selection);
-        }
+        if (auto seq = araDoc.regionSequences.find (playbackRegions[0]->trackID);
+            seq != araDoc.regionSequences.end() && seq->second != nullptr)
+            sequenceRef = seq->second->regionSequenceRef;
+
+        ARAViewSelection selection;
+
+        selection.structSize = sizeof (selection);
+        selection.playbackRegionRefsCount = regionRefs.size();
+        selection.playbackRegionRefs = regionRefs.data();
+        selection.regionSequenceRefsCount = sequenceRef != nullptr ? 1 : 0;
+        selection.regionSequenceRefs = sequenceRef != nullptr ? &sequenceRef : nullptr;
+        selection.timeRange = nullptr;
+
+        notifySelectionTo (pluginInstance, selection);
+
+        for (auto extension : araDoc.additionalEditorViews)
+            if (extension != nullptr && extension != &pluginInstance)
+                notifySelectionTo (*extension, selection);
+    }
+
+    /** Returns the number of playback regions a looping clip of the given length needs.
+        Uses a small tolerance so a length sitting on a loop boundary always produces a
+        stable count - deriving it any other way (e.g. repeated subtraction) can disagree
+        with ceil() by one and make the layout check rebuild the regions endlessly. */
+    static size_t getNumLoopRegions (double clipLengthSecs, double loopLengthSecs)
+    {
+        if (loopLengthSecs <= 0.0)
+            return 1;
+
+        auto count = static_cast<ptrdiff_t> (std::ceil ((clipLengthSecs / loopLengthSecs) - 1.0e-9));
+        return static_cast<size_t> (std::max<ptrdiff_t> (1, count));
+    }
+
+    /** Returns true if the current set of playback regions still matches the given
+        clip state, i.e. no rebuild is needed and updateRange() suffices. */
+    bool playbackRegionLayoutMatches (bool isLooping, double clipLengthSecs, double loopLengthSecs) const
+    {
+        if (builtForLooping != (isLooping && loopLengthSecs > 0.0))
+            return false;
+
+        if (! builtForLooping)
+            return true;
+
+        return playbackRegions.size() == getNumLoopRegions (clipLengthSecs, loopLengthSecs);
     }
 
     /** Rebuilds all playback regions based on whether the clip is looping.
@@ -1672,25 +1800,21 @@ public:
         if (audioModification == nullptr || audioModification->audioModificationRef == nullptr)
             return;
 
-        if (clip.isLooping())
+        // Snapshot the clip state once so the region count always agrees with
+        // playbackRegionLayoutMatches() for the same state
+        auto loopLengthSecs = clip.isLooping() ? clip.getLoopLength().inSeconds() : 0.0;
+        builtForLooping = loopLengthSecs > 0.0;
+
+        if (builtForLooping)
         {
-            auto loopLengthSecs = clip.getLoopLength().inSeconds();
+            auto numRegions = getNumLoopRegions (clip.getPosition().getLength().inSeconds(), loopLengthSecs);
 
-            if (loopLengthSecs <= 0.0)
-                return;
-
-            auto remaining = clip.getPosition().getLength().inSeconds();
-            int iteration = 0;
-
-            while (remaining > 0.0)
+            for (size_t iteration = 0; iteration < numRegions; ++iteration)
             {
                 auto pr = std::make_unique<PlaybackRegionWrapper> (araDoc, clip, araFactory, *audioModification,
-                                                                   iteration);
+                                                                   (int) iteration);
                 addPlaybackRegion (*pr);
                 playbackRegions.push_back (std::move (pr));
-
-                remaining -= loopLengthSecs;
-                ++iteration;
             }
         }
         else
@@ -1721,6 +1845,13 @@ private:
     const ARAFactory& araFactory;
     const ARAPlugInExtensionInstance& pluginInstance;
     bool enabledInConstructor = false;
+    bool builtForLooping = false;
+
+    static void notifySelectionTo (const ARAPlugInExtensionInstance& instance, const ARAViewSelection& selection)
+    {
+        if (instance.editorViewInterface != nullptr)
+            instance.editorViewInterface->notifySelection (instance.editorViewRef, &selection);
+    }
 
     void addPlaybackRegion (PlaybackRegionWrapper& pr)
     {

--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.cpp
@@ -1014,6 +1014,15 @@ ExternalPlugin::~ExternalPlugin()
     deletePluginInstance();
 }
 
+#if TRACKTION_ENABLE_ARA
+void ExternalPlugin::setARADocumentBinding (std::unique_ptr<ARAPluginBinding> newBinding)
+{
+    TRACKTION_ASSERT_MESSAGE_THREAD
+    jassert (araBinding == nullptr || newBinding == nullptr);   // an instance must only ever be bound once
+    araBinding = std::move (newBinding);
+}
+#endif
+
 void ExternalPlugin::selectableAboutToBeDeleted()
 {
     for (auto param : autoParamForParamNumbers)
@@ -1919,9 +1928,24 @@ void ExternalPlugin::deletePluginInstance()
     isAsyncInitialising = false;
     loadError = {};
 
+   #if TRACKTION_ENABLE_ARA
+    // The ARA bind lives and dies with the wrapped instance: unregister the binding
+    // from its document before the instance goes away
+    araBinding.reset();
+   #endif
+
     if (loadedInstance)
+    {
         if (auto pi = loadedInstance->releaseInstance())
-            AsyncPluginDeleter::getInstance()->deletePlugin (std::move (pi));
+        {
+            // ARA-bound instances must be destroyed before their document controller,
+            // so they can't sit in the async deletion queue
+            if (deleteInstanceSynchronously)
+                pi.reset();
+            else
+                AsyncPluginDeleter::getInstance()->deletePlugin (std::move (pi));
+        }
+    }
 }
 
 //==============================================================================

--- a/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.h
+++ b/modules/tracktion_engine/plugins/external/tracktion_ExternalPlugin.h
@@ -14,6 +14,10 @@ namespace tracktion::inline engine {
 // breaking all our saved files. This reverts to the old format
 juce::String createIdentifierString (const juce::PluginDescription&);
 
+#if TRACKTION_ENABLE_ARA
+class ARAPluginBinding;
+#endif
+
 
 /** Wraps a juce::AudioPluginInstance (VST2, VST3, AU, etc.) as a tracktion Plugin.
 
@@ -154,6 +158,28 @@ public:
     /** Returns the underlying juce::AudioPluginInstance, or nullptr if not yet loaded. */
     juce::AudioPluginInstance* getAudioPluginInstance() const;
 
+    /** If enabled, the wrapped juce::AudioPluginInstance is destroyed synchronously when
+        this plugin is deleted rather than via the shared asynchronous deleter. ARA-bound
+        instances need this: the ARA spec requires a bound plugin instance to be destroyed
+        before the document controller it is bound to. */
+    void setDeletesPluginInstanceSynchronously (bool shouldDeleteSynchronously) noexcept    { deleteInstanceSynchronously = shouldDeleteSynchronously; }
+
+   #if TRACKTION_ENABLE_ARA
+    /** Takes ownership of this plugin's ARA document binding
+        (see ARADocumentHolder::bindPluginToDocument). The binding is destroyed -
+        unregistering from the ARA document - just before the wrapped instance is
+        deleted, so it can never dangle or outlive the plugin. */
+    void setARADocumentBinding (std::unique_ptr<ARAPluginBinding>);
+
+    /** Returns true if this plugin owns an ARA document binding, i.e. it was bound via
+        ARADocumentHolder::bindPluginToDocument (the browser/panel case). The bind lasts
+        for the lifetime of the wrapped instance, so a plugin returned from the
+        PluginCache may already be bound.
+        NB: clip-player instances are ARA-bound too, but they're owned by their
+        ARAClipPlayer and never pass through the PluginCache, so they don't show here. */
+    bool isBoundToARADocument() const noexcept          { return araBinding != nullptr; }
+   #endif
+
     /** The plugin's description (format, name, manufacturer, file path, etc.). */
     juce::PluginDescription desc;
 
@@ -182,6 +208,11 @@ private:
     class LoadedInstance;
     std::unique_ptr<LoadedInstance> loadedInstance;
     std::atomic<bool> hasLoadedInstance { false }, isInstancePrepared { false }, isAsyncInitialising { false };
+    bool deleteInstanceSynchronously = false;
+
+   #if TRACKTION_ENABLE_ARA
+    std::unique_ptr<ARAPluginBinding> araBinding;
+   #endif
 
     std::unique_ptr<VSTXML> vstXML;
     int latencySamples = 0;

--- a/modules/tracktion_engine/utilities/tracktion_Engine.cpp
+++ b/modules/tracktion_engine/utilities/tracktion_Engine.cpp
@@ -114,8 +114,10 @@ Engine::~Engine()
     deviceManager.reset();
     midiProgramManager.reset();
 
-    ARAFileReader::cleanUpOnShutdown();
+    // Any queued plugin instance deletions must complete before ARA is uninitialised
+    // and its modules are released - some of those instances may be ARA-bound
     cleanUpDanglingPlugins();
+    ARAFileReader::cleanUpOnShutdown();
     pluginManager.reset();
 
     temporaryFileManager.reset();


### PR DESCRIPTION
- Plugin instance lifecycle (16453): ARA-bound instances are destroyed synchronously (ExternalPlugin::setDeletesPluginInstanceSynchronously) so they always die before their document controller; ~ARADocument releases its bound instance before destroying the controller; ~ARAPluginFactory destroys its dummy instance before uninitializeARA; and Engine::~Engine drains queued plugin deletions before ARA shutdown.
- Looped clips (16459): the playback-region layout is derived once (PlaybackRegionAndSource::getNumLoopRegions / playbackRegionLayoutMatches) so the rebuild check and the rebuild can no longer disagree at loop boundaries and continuously remove/re-add regions.
- Audio sources (16466): stale/missing file info is re-parsed before describing a source to the plugin, and sources are never created with a zero sample rate; ARADocumentHolder::flushStateToValueTree no longer wipes previously-saved archives when a document produced no data (e.g. export-style loads without plugins).
- Musical context (16489): the chord/tempo/bar/key content readers enforce strictly increasing event positions, keeping the later entry.
- View selection (16250): selecting an ARA clip sends all of its playback regions plus its region sequence to every editor view on the document, including additionally bound instances (ARADocument::additionalEditorViews).
- Track properties (16458): RegionSequenceWrapper listens to its Track and pushes rename/recolour/reorder changes immediately, without needing a clip change.
- Bindings (16472/16451): instance roles are parameterised (knownRoles always declares the full set; assignedRoles can be narrowed); ARADocumentHolder::bindPluginToDocument binds browser/panel instances with editor-only assigned roles, and the binding is now an RAII object owned by the bound ExternalPlugin for the lifetime of its instance, making re-binding a cached plugin a safe no-op.