### PR TITLE
Audio: Serialise MIDI output sends with a spin lock (MidiOutput isn't…

### DIFF
--- a/modules/tracktion_engine/playback/devices/tracktion_MidiOutputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_MidiOutputDevice.cpp
@@ -491,6 +491,11 @@ void MidiOutputDevice::sendNoteOffMessages()
 
 void MidiOutputDevice::sendMessageNow (const juce::MidiMessage& message)
 {
+    // juce::MidiOutput isn't thread safe, so serialise sends here as this
+    // can be called from the MIDI dispatch thread, the message thread
+    // (control surface feedback, MMC) and device-detection scans.
+    const juce::SpinLock::ScopedLockType sl (outputDeviceLock);
+
     if (outputDevice != nullptr)
         outputDevice->sendMessageNow (message);
 }

--- a/modules/tracktion_engine/playback/devices/tracktion_MidiOutputDevice.h
+++ b/modules/tracktion_engine/playback/devices/tracktion_MidiOutputDevice.h
@@ -104,6 +104,7 @@ protected:
     double sampleRate = 0;
 
     std::unique_ptr<juce::MidiOutput> outputDevice;
+    juce::SpinLock outputDeviceLock;
     bool sendingMMC = false;
     bool sendControllerMidiClock = false;
     bool softDevice = false;


### PR DESCRIPTION
… thread safe)

juce::MidiOutput is not thread safe, but MidiOutputDevice::sendMessageNow can be reached concurrently from the MIDI dispatch thread, the message thread (control surface feedback, MMC) and device-detection scans. Add a SpinLock, separate from noteOnLock, around the raw send to serialise them.