### PR TITLE
Clip launcher: Fixed clicks in playing launcher clips on playback gra…

### DIFF
--- a/modules/tracktion_engine/playback/graph/tracktion_SlotControlNode.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_SlotControlNode.cpp
@@ -71,6 +71,11 @@ std::vector<Node*> SlotControlNode::getDirectInputNodes()
     return {};
 }
 
+std::vector<Node*> SlotControlNode::getInternalNodes()
+{
+    return orderedNodes;
+}
+
 void SlotControlNode::prepareToPlay (const tracktion::graph::PlaybackInitialisationInfo& info)
 {
     auto info2 = info;

--- a/modules/tracktion_engine/playback/graph/tracktion_SlotControlNode.h
+++ b/modules/tracktion_engine/playback/graph/tracktion_SlotControlNode.h
@@ -33,6 +33,7 @@ public:
     //==============================================================================
     tracktion::graph::NodeProperties getNodeProperties() override;
     std::vector<Node*> getDirectInputNodes() override;
+    std::vector<Node*> getInternalNodes() override;
 
     void prepareToPlay (const tracktion::graph::PlaybackInitialisationInfo&) override;
     bool isReadyToProcess() override;


### PR DESCRIPTION
…ph rebuilds by exposing SlotControlNode children as internal nodes so node state transfer engages

Fixes Tracktion/tracktion_engine#367