### PR TITLE
Examples: Fixed JUCE 9 compatibility - replaced DrawableRectangle thu…

### DIFF
--- a/examples/DemoRunner/demos/ClipLauncherDemo.h
+++ b/examples/DemoRunner/demos/ClipLauncherDemo.h
@@ -1232,7 +1232,7 @@ public:
        #if JUCE_MAJOR_VERSION == 8
         transportReadout.setFont (juce::FontOptions (juce::Font::getDefaultMonospacedFontName(), 14, juce::Font::plain));
        #else
-        transportReadout.setFont ({ juce::Font::getDefaultMonospacedFontName(), 14, juce::Font::plain });
+        transportReadout.setFont (juce::FontOptions { juce::Font::getDefaultMonospacedFontName(), 14, juce::Font::plain });
        #endif
 
         transportReadoutTimer.setCallback ([this]

--- a/examples/common/Utilities.h
+++ b/examples/common/Utilities.h
@@ -407,9 +407,22 @@ struct Thumbnail    : public Component
     }
 
 private:
+    //==============================================================================
+    // In JUCE 9, Drawable is no longer a Component so DrawableRectangle can't be
+    // used as a child cursor. This mimics the parts of its interface we need.
+    struct CursorComponent  : public Component
+    {
+        CursorComponent()                               { setInterceptsMouseClicks (false, false); }
+        void setFill (Colour c)                         { colour = c; repaint(); }
+        void setRectangle (juce::Rectangle<float> r)    { setBounds (r.getSmallestIntegerContainer()); }
+        void paint (Graphics& g) override               { g.fillAll (colour); }
+
+        Colour colour;
+    };
+
     te::TransportControl& transport;
     te::SmartThumbnail smartThumbnail { transport.engine, te::AudioFile (transport.engine), *this, nullptr };
-    DrawableRectangle cursor, pendingCursorTo, pendingCursorAt;
+    CursorComponent cursor, pendingCursorTo, pendingCursorAt;
     te::LambdaTimer cursorUpdater;
     std::optional<int> quantisationNumBars;
     std::optional<te::TimePosition> positionToJumpAt;


### PR DESCRIPTION
…mbnail cursors with a plain Component and used FontOptions instead of the deprecated Font constructor