### PR TITLE
Utilities: Update BackgroundJobManager JobInfo name when a job is renamed

### DIFF
--- a/modules/tracktion_core/tracktion_TestConfig.h
+++ b/modules/tracktion_core/tracktion_TestConfig.h
@@ -23,6 +23,7 @@
 #define ENGINE_UNIT_TESTS_AUTOMATION                    1
 #define ENGINE_UNIT_TESTS_AUTOMATION_CURVE_LIST         1
 #define ENGINE_UNIT_TESTS_AUX_SEND                      1
+#define ENGINE_UNIT_TESTS_BACKGROUND_JOBS               1
 #define ENGINE_UNIT_TESTS_CHANNELCONFIGURATION          1
 #define ENGINE_UNIT_TESTS_CLICKNODE                     1
 #define ENGINE_UNIT_TESTS_CLIPEFFECTS                   1

--- a/modules/tracktion_engine/tracktion_engine_utils.cpp
+++ b/modules/tracktion_engine/tracktion_engine_utils.cpp
@@ -89,6 +89,7 @@ extern "C" char MacGetMacFSRefForREXDLL (FSRef* fsRef)
 #include "utilities/tracktion_ScreenSaverDefeater.cpp"
 #include "utilities/tracktion_ChannelConfiguration.cpp"
 #include "utilities/tracktion_ChannelConfiguration.test.cpp"
+#include "utilities/tracktion_BackgroundJobs.test.cpp"
 
 #ifdef __GNUC__
  #pragma GCC diagnostic pop

--- a/modules/tracktion_engine/utilities/tracktion_BackgroundJobs.h
+++ b/modules/tracktion_engine/utilities/tracktion_BackgroundJobs.h
@@ -236,7 +236,17 @@ inline void ThreadPoolJobWithProgress::setName (const juce::String& newName)
     setJobName (newName);
 
     if (manager != nullptr)
+    {
+        {
+            const juce::ScopedLock sl (manager->jobsLock);
+
+            for (auto pair : manager->jobs)
+                if (&pair->job == this)
+                    pair->info.name = newName;
+        }
+
         manager->triggerAsyncUpdate();
+    }
 }
 
 inline void ThreadPoolJobWithProgress::prepareForJobDeletion()

--- a/modules/tracktion_engine/utilities/tracktion_BackgroundJobs.test.cpp
+++ b/modules/tracktion_engine/utilities/tracktion_BackgroundJobs.test.cpp
@@ -1,0 +1,46 @@
+/*
+    ,--.                     ,--.     ,--.  ,--.
+  ,-'  '-.,--.--.,--,--.,---.|  |,-.,-'  '-.`--' ,---. ,--,--,      Copyright 2024
+  '-.  .-'|  .--' ,-.  | .--'|     /'-.  .-',--.| .-. ||      \   Tracktion Software
+    |  |  |  |  \ '-'  \ `--.|  \  \  |  |  |  |' '-' '|  ||  |       Corporation
+    `---' `--'   `--`--'`---'`--'`--' `---' `--' `---' `--''--'    www.tracktion.com
+
+    Tracktion Engine uses a GPL/commercial licence - see LICENCE.md for details.
+*/
+
+#if TRACKTION_UNIT_TESTS && ENGINE_UNIT_TESTS_BACKGROUND_JOBS
+
+#include <tracktion_engine/../3rd_party/doctest/tracktion_doctest.hpp>
+
+namespace tracktion { inline namespace engine
+{
+
+TEST_SUITE ("tracktion_engine")
+{
+    TEST_CASE ("BackgroundJobManager: setName updates JobInfo")
+    {
+        struct SimpleJob : public ThreadPoolJobWithProgress
+        {
+            using ThreadPoolJobWithProgress::ThreadPoolJobWithProgress;
+
+            ~SimpleJob() override { prepareForJobDeletion(); }
+
+            JobStatus runJob() override             { return jobHasFinished; }
+            float getCurrentTaskProgress() override { return 0.0f; }
+        };
+
+        juce::ScopedJuceInitialiser_GUI juceInit;
+        BackgroundJobManager manager;
+        SimpleJob job { "Old name" };
+
+        manager.addJob (&job, false);
+        CHECK_EQ (manager.getJobInfo (0).name, juce::String ("Old name"));
+
+        job.setName ("New name");
+        CHECK_EQ (manager.getJobInfo (0).name, juce::String ("New name"));
+    }
+}
+
+}} // namespace tracktion { inline namespace engine
+
+#endif // ENGINE_UNIT_TESTS_BACKGROUND_JOBS

--- a/modules/tracktion_engine/utilities/tracktion_BackgroundJobs.test.cpp
+++ b/modules/tracktion_engine/utilities/tracktion_BackgroundJobs.test.cpp
@@ -38,6 +38,10 @@ TEST_SUITE ("tracktion_engine")
 
         job.setName ("New name");
         CHECK_EQ (manager.getJobInfo (0).name, juce::String ("New name"));
+
+        // Take the job out of the pool before it goes out of scope or the pool
+        // could call runJob() on a destroyed object
+        manager.removeJob (&job, true, 30000);
     }
 }
 


### PR DESCRIPTION
Fixes #264