### PR TITLE
Graph: Fixed data race between PreparedNode swapping and pool threads…

### DIFF
--- a/modules/tracktion_core/tracktion_TestConfig.h
+++ b/modules/tracktion_core/tracktion_TestConfig.h
@@ -87,6 +87,7 @@
 #define GRAPH_UNIT_TESTS_AUDIOBUFFERPOOL                1
 #define GRAPH_UNIT_TESTS_SEMAPHORE                      1
 #define GRAPH_UNIT_TESTS_ALLOCATION                     1
+#define GRAPH_UNIT_TESTS_LOCKFREENODEPLAYER             1
 
 // Benchmarks
 #define CORE_BENCHMARKS_TEMPO                           1

--- a/modules/tracktion_graph/tracktion_graph.cpp
+++ b/modules/tracktion_graph/tracktion_graph.cpp
@@ -42,6 +42,7 @@
 
 #include "tracktion_graph/tracktion_MultiThreadedNodePlayer.cpp"
 #include "tracktion_graph/tracktion_LockFreeMultiThreadedNodePlayer.cpp"
+#include "tracktion_graph/tracktion_LockFreeMultiThreadedNodePlayer.test.cpp"
 #include "tracktion_graph/tracktion_NodePlayerThreadPools.cpp"
 
 #include "tracktion_graph/nodes/tracktion_ConnectedNode.test.cpp"

--- a/modules/tracktion_graph/tracktion_graph/tracktion_LockFreeMultiThreadedNodePlayer.cpp
+++ b/modules/tracktion_graph/tracktion_graph/tracktion_LockFreeMultiThreadedNodePlayer.cpp
@@ -102,6 +102,13 @@ int LockFreeMultiThreadedNodePlayer::process (const Node::ProcessContext& pc)
     if (! preparedNode->graph->rootNode)
         return -1;
 
+    // Publish the current PreparedNode to the pool threads. This must happen in
+    // every process call that could have swapped a new PreparedNode in via
+    // retainRealTime above (including the single-threaded paths below), so that
+    // by the time postNewGraph destroys a retired PreparedNode, the pool
+    // threads can no longer pick it up
+    threadPool->setCurrentNode (preparedNode);
+
     // Reset the stream range
     numSamplesToProcess = pc.numSamples;
     referenceSampleRange = pc.referenceSampleRange;
@@ -157,6 +164,10 @@ void LockFreeMultiThreadedNodePlayer::clearNode()
 {
     // N.B. The threads will be trying to read the preparedNodes so we need to actually stop these first
     clearThreads();
+
+    // The threads have now been stopped so it's safe to reset the current node
+    // pointer, ensuring newly created threads can't read the cleared objects
+    threadPool->setCurrentNode (nullptr);
 
     rootNode = nullptr;
     lastGraphPosted = nullptr;
@@ -273,7 +284,17 @@ void LockFreeMultiThreadedNodePlayer::postNewGraph (std::unique_ptr<NodeGraph> n
 
     lastGraphPosted = newPreparedNode.graph.get();
     lastAudioBufferPoolPosted = newPreparedNode.audioBufferPool.get();
-    preparedNodeObject.pushNonRealTime (std::move (newPreparedNode));
+
+    if (auto retiredPreparedNode = preparedNodeObject.pushNonRealTime (std::move (newPreparedNode)))
+    {
+        // If an old PreparedNode was returned, it was either never swapped in
+        // on the audio thread (so no pool thread can have seen it), or it was
+        // retired by a swap, in which case the audio thread has since published
+        // a newer PreparedNode via setCurrentNode. Either way, no pool thread
+        // can newly obtain it, but one could still be part-way through reading
+        // it, so wait for them to finish before it is destroyed
+        threadPool->waitForThreadsToQuiesce();
+    }
 }
 
 //==============================================================================
@@ -367,8 +388,6 @@ void LockFreeMultiThreadedNodePlayer::resetProcessQueue (PreparedNode& preparedN
     // Make sure this is only incremented after all the nodes have been queued
     // or the threads will start queueing Nodes at the same time
     numNodesQueued += numNodesJustQueued;
-
-    threadPool->setCurrentNode (&preparedNode);
 
     if (int numThreadsToSignal = (int) numNodesQueued.load(); numThreadsToSignal > 1)
         threadPool->signal (numThreadsToSignal);

--- a/modules/tracktion_graph/tracktion_graph/tracktion_LockFreeMultiThreadedNodePlayer.h
+++ b/modules/tracktion_graph/tracktion_graph/tracktion_LockFreeMultiThreadedNodePlayer.h
@@ -165,13 +165,37 @@ public:
         */
         bool process()
         {
-            if (auto cpn = currentPreparedNode.load())
-                return player.processNextFreeNode (*cpn);
+            // The numActiveProcessCalls counter brackets all access to the
+            // current PreparedNode from pool threads so that
+            // waitForThreadsToQuiesce can tell when a retired PreparedNode can
+            // no longer be being read and is safe to destroy. The default
+            // sequentially-consistent ordering is required for that guarantee
+            numActiveProcessCalls.fetch_add (1);
+            bool processedAnyNodes = false;
 
-            return false;
+            if (auto cpn = currentPreparedNode.load())
+                processedAnyNodes = player.processNextFreeNode (*cpn);
+
+            numActiveProcessCalls.fetch_sub (1);
+
+            return processedAnyNodes;
         }
 
-        /** Sets the current PreparedNode in use. This should live as long as the threads are running once set. */
+        /** Waits until no pool threads are inside a process() call.
+            Call this from a non-real-time thread, once a retired PreparedNode is no
+            longer reachable via setCurrentNode, to ensure no pool threads can still
+            be reading it before it is destroyed.
+        */
+        void waitForThreadsToQuiesce()
+        {
+            while (numActiveProcessCalls.load() != 0)
+                std::this_thread::yield();
+        }
+
+        /** Sets the current PreparedNode in use.
+            Once set, this must stay alive until a newer PreparedNode has been set
+            here and waitForThreadsToQuiesce has subsequently returned.
+        */
         void setCurrentNode (LockFreeMultiThreadedNodePlayer::PreparedNode* nodeInUse)
         {
             currentPreparedNode = nodeInUse;
@@ -184,6 +208,7 @@ public:
 
     private:
         std::atomic<bool> threadsShouldExit { false };
+        std::atomic<int> numActiveProcessCalls { 0 };
         std::atomic<LockFreeMultiThreadedNodePlayer::PreparedNode*> currentPreparedNode { nullptr };
     };
 

--- a/modules/tracktion_graph/tracktion_graph/tracktion_LockFreeMultiThreadedNodePlayer.test.cpp
+++ b/modules/tracktion_graph/tracktion_graph/tracktion_LockFreeMultiThreadedNodePlayer.test.cpp
@@ -1,0 +1,111 @@
+/*
+    ,--.                     ,--.     ,--.  ,--.
+  ,-'  '-.,--.--.,--,--.,---.|  |,-.,-'  '-.`--' ,---. ,--,--,      Copyright 2024
+  '-.  .-'|  .--' ,-.  | .--'|     /'-.  .-',--.| .-. ||      \   Tracktion Software
+    |  |  |  |  \ '-'  \ `--.|  \  \  |  |  |  |' '-' '|  ||  |       Corporation
+    `---' `--'   `--`--'`---'`--'`--' `---' `--' `---' `--''--'    www.tracktion.com
+
+    Tracktion Engine uses a GPL/commercial licence - see LICENCE.md for details.
+*/
+
+#if TRACKTION_UNIT_TESTS && GRAPH_UNIT_TESTS_LOCKFREENODEPLAYER
+
+#include "../../3rd_party/doctest/tracktion_doctest.hpp"
+
+namespace tracktion::inline graph {
+
+TEST_SUITE ("tracktion_graph")
+{
+    TEST_CASE ("LockFreeMultiThreadedNodePlayer: concurrent graph swap stress")
+    {
+        // Repeatedly posts new graphs from a non-real-time thread whilst blocks
+        // are being processed and pool threads are running. This stresses the
+        // PreparedNode hand-over between the pushing thread, the audio thread
+        // and the free-running pool threads, which has previously caused data
+        // races where a pool thread could read a PreparedNode whilst it was
+        // being swapped or destroyed. Run under TSan/ASan to catch regressions
+        constexpr double sampleRate = 44100.0;
+        constexpr int blockSize = 64;
+        constexpr int numBlocksToProcess = 2000;
+
+        auto makeGraph = [] (int numSources)
+        {
+            std::vector<std::unique_ptr<Node>> nodes;
+
+            for (int i = 0; i < numSources; ++i)
+                nodes.push_back (std::make_unique<SinNode> (220.0f * (float) (i + 1)));
+
+            return std::make_unique<BasicSummingNode> (std::move (nodes));
+        };
+
+        for (auto strategy : { ThreadPoolStrategy::realTime, ThreadPoolStrategy::lightweightSemHybrid })
+        {
+            LockFreeMultiThreadedNodePlayer player { getPoolCreatorFunction (strategy) };
+            player.setNumThreads (4);
+            player.setNode (makeGraph (4), sampleRate, blockSize);
+
+            std::atomic<bool> shouldStopPushing { false };
+            std::atomic<int> numGraphsPushed { 0 };
+
+            std::thread pushingThread ([&]
+            {
+                for (int i = 0; ! shouldStopPushing; ++i)
+                {
+                    player.setNode (makeGraph (2 + (i % 6)), sampleRate, blockSize);
+                    ++numGraphsPushed;
+
+                    if ((i % 8) == 0)
+                        std::this_thread::yield();
+                }
+            });
+
+            choc::buffer::ChannelArrayBuffer<float> audioBuffer;
+            audioBuffer.resize ({ (choc::buffer::ChannelCount) 1, (choc::buffer::FrameCount) blockSize });
+            tracktion_engine::MidiMessageArray midi;
+            int64_t numSamplesDone = 0;
+
+            auto processBlock = [&]
+            {
+                audioBuffer.clear();
+                midi.clear();
+                const auto referenceSampleRange = juce::Range<int64_t>::withStartAndLength (numSamplesDone, blockSize);
+                player.process ({ (choc::buffer::FrameCount) blockSize, referenceSampleRange, { audioBuffer.getView(), midi } });
+                numSamplesDone += blockSize;
+            };
+
+            for (int block = 0; block < numBlocksToProcess; ++block)
+            {
+                processBlock();
+
+                // Give the pushing thread a chance to get in between blocks
+                if ((block % 16) == 0)
+                    std::this_thread::yield();
+            }
+
+            shouldStopPushing = true;
+            pushingThread.join();
+
+            CHECK (numGraphsPushed.load() > 0);
+
+            // Check the player still produces output after all the swapping
+            player.setNode (makeGraph (4), sampleRate, blockSize);
+
+            float maxMagnitude = 0.0f;
+
+            for (int block = 0; block < 10; ++block)
+            {
+                processBlock();
+                auto juceBuffer = toAudioBuffer (audioBuffer.getView());
+                maxMagnitude = std::max (maxMagnitude, juceBuffer.getMagnitude (0, 0, juceBuffer.getNumSamples()));
+            }
+
+            CHECK (maxMagnitude > 0.0f);
+
+            player.clearNode();
+        }
+    }
+}
+
+} // namespace tracktion::inline graph
+
+#endif

--- a/modules/tracktion_graph/utilities/tracktion_LockFreeObject.h
+++ b/modules/tracktion_graph/utilities/tracktion_LockFreeObject.h
@@ -25,6 +25,14 @@ namespace tracktion::inline graph {
     Calls to pushNonRealTime may have to wait for the real time access to complete,
     signified by a call to releaseRealTime.
 
+    Objects are stored on the heap so they have a stable identity: once an object
+    has been swapped in by retainRealTime, its address never changes and its
+    contents are never written by this class again. When a subsequent push is
+    consumed on the real-time thread, the previous object is retired rather than
+    mutated, and ownership of it is handed back to the caller from the next
+    pushNonRealTime call so it can be destroyed once any concurrent readers of
+    it have finished.
+
     Additionally, you may want to clear the objects e.g. releasing some resource
     they have stored. This can be done with the clear call.
     Whilst this is happening, retainRealTime will still be lock-free but will
@@ -41,36 +49,58 @@ public:
     */
     LockFreeObject()
     {
-        static_assert (std::is_default_constructible_v<ObjectType>);
-        static_assert (std::is_nothrow_move_assignable_v<ObjectType>);
+        static_assert (std::is_move_constructible_v<ObjectType>);
     }
 
-    /** Clears the object and any pending object by assigining them defaultly constructed objects. */
+    /** Clears the current and any pending object.
+        N.B. This destroys the objects so only call it once no other threads can
+        be concurrently reading them (including any object previously swapped in
+        by retainRealTime whose pointer readers may still hold).
+    */
     void clear()
     {
         // Obtain the locks for both the objects
         std::scoped_lock sl (clearObjectsMutex);
         std::scoped_lock sl2 (pushingObjectMutex);
 
-        pendingObjectStorage = {};
-        objectStorage = {};
+        pendingObjectStorage.reset();
+        objectStorage.reset();
 
         pendingObject = nullptr;
     }
 
-    /** Pushes a new object to be picked up on the real time thread. */
-    void pushNonRealTime (ObjectType&& newObj)
+    /** Pushes a new object to be picked up on the real time thread.
+        Returns the object this replaces which will either be a previously
+        pushed object that was never swapped in on the real-time thread, or an
+        object that has been retired by a retainRealTime call swapping in a
+        newer one. In the latter case, other threads may still be reading the
+        retired object if they obtained its pointer before the swap, so callers
+        must wait for those readers to finish before destroying it.
+    */
+    [[nodiscard]] std::unique_ptr<ObjectType> pushNonRealTime (ObjectType&& newObj)
     {
-        // Obtain the lock on the pending object
-        std::scoped_lock sl (pushingObjectMutex);
+        // Allocate the new storage before taking the lock as retainRealTime
+        // will spin on it from the real-time thread
+        auto newStorage = std::make_unique<ObjectType> (std::move (newObj));
 
-        pendingObjectStorage = std::move (newObj);
-        pendingObject = &pendingObjectStorage;
+        std::unique_ptr<ObjectType> replacedObject;
+
+        {
+            // Obtain the lock on the pending object
+            std::scoped_lock sl (pushingObjectMutex);
+
+            replacedObject = std::move (pendingObjectStorage);
+            pendingObjectStorage = std::move (newStorage);
+            pendingObject = &pendingObjectStorage;
+        }
+
+        return replacedObject;
     }
 
     /** Retains the object for use in a real time thread.
         If a previous push call has finished, this will update and use the newly pushed object.
-        If a clear call is in progress this will return nullptr.
+        If a clear call is in progress, or no object has been pushed yet, this
+        will return nullptr.
 
         This must be matched with a corresponding call to releaseRealTime(). To Ensure this,
         use the ScopedRealTimeAccess helper class.
@@ -92,7 +122,9 @@ public:
         {
             needToUnlockPushingObjectMutex = true;
 
-            // Move any penidng object in to the main objectStorage
+            // Swap any pending object in to use, retiring the current one.
+            // N.B. This only swaps the owning pointers, the objects themselves
+            // don't move so pointers to them held by other threads stay valid
             if (auto newObject = pendingObject.exchange (nullptr))
                 std::swap (objectStorage, *newObject);
         }
@@ -102,7 +134,7 @@ public:
         }
 
         // Then return the main stored object
-        return &objectStorage;
+        return objectStorage.get();
     }
 
     /** Releases the use of the object from a previous call to retainRealTime. */
@@ -151,8 +183,8 @@ public:
     }
 
 private:
-    ObjectType objectStorage, pendingObjectStorage;
-    std::atomic<ObjectType*> pendingObject { nullptr };
+    std::unique_ptr<ObjectType> objectStorage, pendingObjectStorage;
+    std::atomic<std::unique_ptr<ObjectType>*> pendingObject { nullptr };
     RealTimeSpinLock pushingObjectMutex, clearObjectsMutex;
     bool needToUnlockPushingObjectMutex = false, needToUnlockClearObjectsMutex = true;
 };


### PR DESCRIPTION
… in LockFreeMultiThreadedNodePlayer

LockFreeObject now heap-allocates its objects so they have a stable identity: retainRealTime swaps owning pointers rather than object contents, so a published PreparedNode is never written again and pool threads holding a stale pointer read valid memory. pushNonRealTime returns the retired object and the player waits for pool threads to quiesce (via a read-section counter in ThreadPool::process) before destroying it. The current PreparedNode is now republished every process block and cleared in clearNode.

Adds a concurrent graph swap stress test that reliably surfaces the old race under TSan.