### PR TITLE
Audio: Fixed an occasional Debug abort when launching stretched clips

### DIFF
--- a/modules/tracktion_engine/timestretch/tracktion_ReadAheadTimeStretcher.cpp
+++ b/modules/tracktion_engine/timestretch/tracktion_ReadAheadTimeStretcher.cpp
@@ -217,8 +217,20 @@ int ReadAheadTimeStretcher::popData (float* const* outChannels, int numSamples)
 
     if (outputFifo.getNumReady() <= numSamples)
     {
-        [[ maybe_unused ]] const int numPopped = processNextBlock (true);
-        assert (numPopped > 0 && "Not enough input frames pushed");
+        // A stretcher that has just been reset can consume input frames without
+        // producing any output, so keep processing whilst input is being consumed.
+        // If no progress can be made, return what is ready (which may be nothing)
+        // and the caller can push more input frames and pop again
+        for (;;)
+        {
+            const auto numInputFramesBefore = inputFifo.getNumReady();
+
+            if (processNextBlock (true) > 0)
+                break;
+
+            if (inputFifo.getNumReady() >= numInputFramesBefore)
+                break;
+        }
     }
 
     const int numToRead = std::min (numSamples, outputFifo.getNumReady());

--- a/modules/tracktion_engine/timestretch/tracktion_TimeStretch.cpp
+++ b/modules/tracktion_engine/timestretch/tracktion_TimeStretch.cpp
@@ -711,6 +711,10 @@ struct RubberBandStretcher  : public TimeStretcher::Stretcher
     void reset() override
     {
         rubberBandStretcher.reset();
+
+        // Resetting the stretcher restores its start delay so the padding and
+        // dropping needs to be set up again by the next setSpeedAndPitch call
+        numSamplesToDrop = -1;
     }
 
     bool setSpeedAndPitch (float speedRatio, float semitonesUp) override


### PR DESCRIPTION
Fixes the Windows Debug TestRunner crash in CI run [32765820746](https://github.com/Tracktion/tracktion_engine/actions/runs/32765820746), where the new "Clip launcher: switching scenes moves all tracks to the new scene" test aborted on the ReadAheadTimeStretcher assertion `numPopped > 0 && "Not enough input frames pushed"`.

## Root cause
- The RubberBand wrapper only arms its startup pad/drop handling once (the `numSamplesToDrop == -1` check in `setSpeedAndPitch`). After any subsequent `reset()` (e.g. a slot clip launch calling `setPosition`), RubberBand's start delay is restored but the pad/drop compensation is not, so the freshly reset stretcher can consume `getFramesNeeded()` input frames and produce zero output.
- Normally the read-ahead background thread performs that first process call, where a zero return is tolerated. When it is starved (2-core CI VM, multiple stretcher instances priming at once), the audio thread takes the synchronous path in `popData` and hits the assertion, which wrongly assumes enough input implies at least one output frame. Release builds took the same path but just produced a silent block and recovered.

## Changes
- `RubberBandStretcher::reset()` now re-arms the startup padding/dropping so the next `setSpeedAndPitch` call sets it up again, matching first-initialisation behaviour.
- `RubberBandStretcher::reset()` also clears `hasDoneFinalBlock`, so a stream that was flushed and then reset marks its final block again on a later flush.
- `ReadAheadTimeStretcher::popData` replaces the single process call and assertion with a loop that keeps processing whilst input is being consumed, and otherwise returns whatever is ready (possibly nothing) per the documented contract, letting the caller push more frames and pop again.

## Testing
Full TestRunner suite passes on macOS Debug (327 test cases, 10378 assertions), including the clip launcher and TimeStretcher suites. The failing scene-switch test also passed 15 consecutive isolated runs.
