### PR TITLE
Threading: Fixed a rare crash when a MessageThreadCallback wait times out as the callback completes

### DIFF
--- a/modules/tracktion_engine/utilities/tracktion_AsyncFunctionUtils.h
+++ b/modules/tracktion_engine/utilities/tracktion_AsyncFunctionUtils.h
@@ -155,14 +155,22 @@ private:
 
 //==============================================================================
 /** Calls a function on the message thread checking a calling thread for an exit signal. */
-class MessageThreadCallback   : private juce::AsyncUpdater
+class MessageThreadCallback
 {
 public:
     MessageThreadCallback() = default;
-    ~MessageThreadCallback() override       { cancelPendingUpdate(); }
+
+    /** Blocks until any in-flight callback has finished and prevents a pending
+        one from starting, so the message thread can never touch a dangling this.
+    */
+    virtual ~MessageThreadCallback()
+    {
+        const std::scoped_lock sl (state->mutex);
+        state->cancelled = true;
+    }
 
     /** Returns true if the callback has completed. */
-    bool hasFinished() const noexcept       { return finished; }
+    bool hasFinished() const noexcept       { return state->finished; }
 
     /** Triggers the callback to happen on the message thread and blocks
         until it has returned or the thread signals it should exit.
@@ -171,22 +179,26 @@ public:
     {
         if (juce::MessageManager::getInstance()->isThisTheMessageThread())
         {
-            handleAsyncUpdate();
+            performOnMessageThread (*this, *state);
             return;
         }
 
-        triggerAsyncUpdate();
+        // The state is co-owned by the lambda so the waiter can always be
+        // safely signalled, even if this object has been destroyed. The this
+        // pointer is only used under the state mutex whilst not cancelled,
+        // which excludes the destructor
+        juce::MessageManager::callAsync ([this, s = state]
+                                         {
+                                             performOnMessageThread (*this, *s);
+                                         });
 
         if (auto job = juce::ThreadPoolJob::getCurrentThreadPoolJob())
         {
             while (! (job->shouldExit() || hasFinished()))
-                waiter.wait (50);
+                state->waiter.wait (50);
 
             if (job->shouldExit())
-            {
-                hasBeenCancelled = true;
-                cancelPendingUpdate();
-            }
+                cancel();
 
             return;
         }
@@ -194,13 +206,10 @@ public:
         if (auto thread = juce::Thread::getCurrentThread())
         {
             while (! (thread->threadShouldExit() || hasFinished()))
-                waiter.wait (50);
+                state->waiter.wait (50);
 
             if (thread->threadShouldExit())
-            {
-                hasBeenCancelled = true;
-                cancelPendingUpdate();
-            }
+                cancel();
 
             return;
         }
@@ -208,13 +217,10 @@ public:
         if (isCurrentThreadSupplyingExitStatus())
         {
             while (! (shouldCurrentThreadExit() || hasFinished()))
-                waiter.wait (50);
+                state->waiter.wait (50);
 
             if (shouldCurrentThreadExit())
-            {
-                hasBeenCancelled = true;
-                cancelPendingUpdate();
-            }
+                cancel();
 
             return;
         }
@@ -222,7 +228,7 @@ public:
         // If you get a deadlock here, it's probably because your MessageManager isn't
         // actually running and dispatching messages. This shouldn't be called with a
         // blocked message manager
-        waiter.wait();
+        state->waiter.wait();
 
         if (! hasFinished())
         {
@@ -234,20 +240,35 @@ public:
     virtual void performAction() = 0;
 
 private:
-    std::atomic<bool> finished { false }, hasBeenCancelled { false };
-    juce::WaitableEvent waiter;
+    struct State
+    {
+        std::mutex mutex;
+        std::atomic<bool> finished { false }, cancelled { false };
+        juce::WaitableEvent waiter;
+    };
 
-    void handleAsyncUpdate() override
+    std::shared_ptr<State> state { std::make_shared<State>() };
+
+    static void performOnMessageThread (MessageThreadCallback& callback, State& s)
     {
         CRASH_TRACER
         TRACKTION_ASSERT_MESSAGE_THREAD
+        const std::scoped_lock sl (s.mutex);
 
-        if (hasBeenCancelled)
+        if (s.cancelled)
             return;
 
-        performAction();
-        finished = true;
-        waiter.signal();
+        callback.performAction();
+        s.finished = true;
+        s.waiter.signal();
+    }
+
+    // Blocks until any in-flight callback has finished, then prevents a
+    // pending one from running
+    void cancel()
+    {
+        const std::scoped_lock sl (state->mutex);
+        state->cancelled = true;
     }
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MessageThreadCallback)


### PR DESCRIPTION
Fixes the macOS Debug TestRunner crash in CI run [32765820746](https://github.com/Tracktion/tracktion_engine/actions/runs/32765820746), where the `EditLoad` test aborted with an uncaught `std::system_error: mutex lock failed: Invalid argument` on the message thread.

## Root cause
`callBlocking` creates a stack-allocated `BlockingFunction` and waits for the message thread to run it. On threads that poll for an exit signal (`ThreadPoolJob`, `juce::Thread`, or a `ScopedThreadExitStatusEnabler` thread such as the `EditLoader` load thread), the wait is a `waiter.wait (50)` poll loop. On the message thread, `handleAsyncUpdate` set `finished = true` and *then* called `waiter.signal()`. If the poll woke on its timeout in that window, it saw `finished`, returned, and destroyed the stack object - the message thread then signalled a destroyed `juce::WaitableEvent`. JUCE 9's `WaitableEvent` is `std::mutex` based, so locking the destroyed mutex throws, and the exception escapes into the noexcept `MessageQueue::runLoopCallback` and terminates. Under the previous pthread-based implementation this was silent UB, which is why the race only started crashing CI recently.

There was a second, rarer hole: cancellation via a thread-exit signal during an in-flight callback destroyed the whole object while `performAction()` was still running (`cancelPendingUpdate` cannot stop a callback that has already started).

## Changes
- The completion state (`finished`, `cancelled`, the `WaitableEvent`) moves into a `std::shared_ptr` state block co-owned by the message-thread closure, so signalling always targets a live event even if the callback owner is gone.
- `AsyncUpdater` is replaced by `MessageManager::callAsync` plus a cancelled flag checked under a state mutex. `performAction()` runs under that mutex and both `cancel()` and the destructor take it before setting `cancelled`, so destruction either happens strictly before the callback starts (it then no-ops) or strictly after it finishes.
- Public behaviour of `MessageThreadCallback`/`callBlocking` is unchanged, including throwing `runtime_error` when cancelled before completion. One semantic difference: on cancellation the destructor now briefly blocks if the callback is mid-flight instead of racing it.

## Testing
- Reproduced the original crash locally at roughly 1-in-100 runs by running 8 concurrent `TestRunner -tc=EditLoad` instances (CPU contention is required, matching the 2-core CI VM); an lldb breakpoint on `__throw_system_error` confirmed the exact throw site in `MessageThreadCallback::handleAsyncUpdate` → `WaitableEvent::signal`.
- With the fix: 480/480 contended runs pass, and the full TestRunner suite passes on macOS Debug (327 test cases, 10378 assertions).