### PR TITLE
Testing: Gave waitForFileToBeMapped a 30s timeout so tests fail instead of hanging when a file is never mapped

### DIFF
--- a/modules/tracktion_engine/testing/tracktion_EnginePlayer.h
+++ b/modules/tracktion_engine/testing/tracktion_EnginePlayer.h
@@ -195,10 +195,21 @@ inline void waitForFileToBeMapped (const AudioFile& af)
     using namespace std::literals;
     assert (af.engine);
 
+    // A file only gets mapped whilst something holds a cache Reader for it, so
+    // waiting on a file no playing Edit references would otherwise spin forever
+    const auto timeout = std::chrono::steady_clock::now() + 30s;
+
     for (;;)
     {
         if (af.engine->getAudioFileManager().cache.hasMappedReader (af, 0))
             return;
+
+        if (std::chrono::steady_clock::now() > timeout)
+        {
+            TRACKTION_LOG_ERROR ("waitForFileToBeMapped timed out: " + af.getFile().getFullPathName());
+            jassertfalse;
+            return;
+        }
 
         std::this_thread::sleep_for (100ms);
     }


### PR DESCRIPTION
`test_utilities::waitForFileToBeMapped` was an unbounded poll loop. A file only becomes mapped while something holds an `AudioFileCache` reader for it, so waiting on a file that no playing Edit references spins forever - this intermittently hung Waveform's `run-tests` CI path (a test suite waited on files from an earlier test's destroyed edit, racing `AudioFileCache::purgeOldFiles`).

The wait now gives up after 30s with a `TRACKTION_LOG_ERROR` and a `jassertfalse`, then returns, so the calling test fails on its subsequent assertions instead of hanging the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)