### PR TITLE
MIDI: Removed the legacy ScopedEventsList selected-notes render restriction

### DIFF
--- a/modules/tracktion_engine/midi/tracktion_MidiList.cpp
+++ b/modules/tracktion_engine/midi/tracktion_MidiList.cpp
@@ -1912,7 +1912,6 @@ juce::MidiMessageSequence MidiList::createDefaultPlaybackMidiSequence (const Mid
 
     auto& notes = list.getNotes();
     const auto numNotes = notes.size();
-    auto selectedEvents = clip.getSelectedEvents();
 
     auto grooveTemplate = clip.edit.engine.getGrooveTemplateManager().getTemplateByName (clip.getGrooveTemplate());
 
@@ -1957,9 +1956,6 @@ juce::MidiMessageSequence MidiList::createDefaultPlaybackMidiSequence (const Mid
         {
             auto& note = *notes.getUnchecked (i);
 
-            if (selectedEvents != nullptr && ! selectedEvents->isSelected (&note))
-                continue;
-
             // check for subsequent overlaps
             auto thisNoteStart = note.getStartBeat();
 
@@ -1994,12 +1990,7 @@ juce::MidiMessageSequence MidiList::createDefaultPlaybackMidiSequence (const Mid
         MPEChannelAssigner assigner (destSequence, clip, timeBase, grooveTemplate);
 
         for (auto note : notes)
-        {
-            if (selectedEvents != nullptr && ! selectedEvents->isSelected (note))
-                continue;
-
             assigner.addNote (*note);
-        }
     }
 
     // Add the SysEx events:

--- a/modules/tracktion_engine/model/clips/tracktion_MidiClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_MidiClip.cpp
@@ -287,17 +287,6 @@ std::unique_ptr<MidiList> MidiClip::createSequenceLooped (MidiList& sourceSequen
     }
 }
 
-MidiClip::ScopedEventsList::ScopedEventsList (MidiClip& c, SelectedMidiEvents* e)
-    : clip (c)
-{
-    clip.setSelectedEvents (e);
-}
-
-MidiClip::ScopedEventsList::~ScopedEventsList()
-{
-    clip.setSelectedEvents (nullptr);
-}
-
 //==============================================================================
 void MidiClip::extendStart (TimePosition newStartTime)
 {
@@ -806,11 +795,6 @@ void MidiClip::valueTreePropertyChanged (juce::ValueTree& tree, const juce::Iden
         else if (id == IDs::currentTake)
         {
             currentTake.forceUpdateOfCachedValue();
-
-            for (SelectionManager::Iterator sm; sm.next();)
-                if (sm->isSelected (getSelectedEvents()))
-                    sm->deselectAll();
-
             clearCachedLoopSequence();
         }
         else if (id == IDs::launchQuantisation || id == IDs::useClipLaunchQuantisation)

--- a/modules/tracktion_engine/model/clips/tracktion_MidiClip.h
+++ b/modules/tracktion_engine/model/clips/tracktion_MidiClip.h
@@ -32,8 +32,6 @@ public:
     MidiList& getSequenceLooped();
     std::unique_ptr<MidiList> createSequenceLooped (MidiList& sourceSequence);
 
-    const SelectedMidiEvents* getSelectedEvents() const             { return selectedEvents; }
-
     //==============================================================================
     /** Can be used to disable proxy sequence generation for this clip.
         N.B. If disabled, the audio engine will perform quantisation and groove
@@ -158,18 +156,6 @@ public:
     PatternGenerator* getPatternGenerator() override;
     void pitchTempoTrackChanged() override;
 
-    //==============================================================================
-    /** Temporarily limits the notes to use. */
-    struct ScopedEventsList
-    {
-        ScopedEventsList (MidiClip&, SelectedMidiEvents*);
-        ~ScopedEventsList();
-
-    private:
-        MidiClip& clip;
-        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ScopedEventsList)
-    };
-
 protected:
     void valueTreePropertyChanged (juce::ValueTree&, const juce::Identifier&) override;
     void valueTreeChildAdded (juce::ValueTree&, juce::ValueTree&) override;
@@ -196,13 +182,9 @@ private:
     juce::CachedValue<juce::String> grooveTemplate;
 
     bool shouldWarnAboutMultiChannel = false;
-    SelectedMidiEvents* selectedEvents = nullptr;
 
     mutable std::unique_ptr<MidiList> cachedLoopedSequence;
     MidiCompManager::Ptr midiCompManager;
-
-    //==============================================================================
-    void setSelectedEvents (SelectedMidiEvents* events)     { selectedEvents = events; }
 
     //==============================================================================
     MidiList* getMidiListForState (const juce::ValueTree&);


### PR DESCRIPTION
Removes `MidiClip::ScopedEventsList` and its supporting plumbing, which existed only so Waveform's old "Render Notes" action could temporarily restrict a clip to the selected notes during a render. That action has been removed from the app (users can mute unwanted notes before rendering instead), leaving this mechanism unused.

- Removed `MidiClip::ScopedEventsList`, the `selectedEvents` member and its getter/setter
- Removed the selected-note filters from the sequence generation in `tracktion_MidiList.cpp`
- Removed the take-change deselect loop that only had an effect while a scoped render was in flight

No behaviour change for normal playback or rendering: the removed filters were no-ops unless a `ScopedEventsList` was alive. TestRunner passes (19026 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)