### PR TITLE
Audio: Added an abort hook to analyseAudioFile so callers' threads can stop mid-file

### DIFF
--- a/modules/tracktion_engine/audio_files/tracktion_AudioFileAnalyser.cpp
+++ b/modules/tracktion_engine/audio_files/tracktion_AudioFileAnalyser.cpp
@@ -359,7 +359,8 @@ namespace audio_analysis_utils
 
 //==============================================================================
 tl::expected<juce::var, juce::String> analyseAudioFile (Engine& engine, const juce::File& file,
-                                                        const std::vector<AudioFileAnalyser*>& analysers)
+                                                        const std::vector<AudioFileAnalyser*>& analysers,
+                                                        const std::function<bool()>& shouldAbort)
 {
     using namespace audio_analysis_utils;
 
@@ -382,6 +383,9 @@ tl::expected<juce::var, juce::String> analyseAudioFile (Engine& engine, const ju
 
     for (SampleCount position = 0; position < (SampleCount) reader->lengthInSamples;)
     {
+        if (shouldAbort && shouldAbort())
+            return tl::unexpected (TRANS("Analysis cancelled"));
+
         const auto numThisTime = (int) std::min ((SampleCount) blockSize,
                                                  (SampleCount) reader->lengthInSamples - position);
 
@@ -421,7 +425,7 @@ tl::expected<juce::var, juce::String> analyseAudioFile (Engine& engine, const ju
     for (auto& analyser : owned)
         analysers.push_back (analyser.get());
 
-    return analyseAudioFile (engine, file, analysers);
+    return analyseAudioFile (engine, file, analysers, options.shouldAbort);
 }
 
 } // namespace tracktion::inline engine

--- a/modules/tracktion_engine/audio_files/tracktion_AudioFileAnalyser.h
+++ b/modules/tracktion_engine/audio_files/tracktion_AudioFileAnalyser.h
@@ -47,6 +47,11 @@ struct AudioAnalysisOptions
     bool spectrum = true;       ///< Banded energies, spectral centroid/rolloff, low/mid/high balance
     bool envelope = true;       ///< Downsampled peak/RMS dynamics curve over time
     int envelopePoints = 100;   ///< Number of points in the dynamics curve
+
+    /** Checked between blocks while the file streams; return true to abort
+        the analysis, which then fails rather than returning partial results.
+        Lets a caller's thread shut down promptly mid-way through a long file. */
+    std::function<bool()> shouldAbort;
 };
 
 //==============================================================================
@@ -56,7 +61,8 @@ struct AudioAnalysisOptions
     for compactness: the output is designed to be read by an LLM.
 */
 tl::expected<juce::var, juce::String> analyseAudioFile (Engine&, const juce::File&,
-                                                        const std::vector<AudioFileAnalyser*>&);
+                                                        const std::vector<AudioFileAnalyser*>&,
+                                                        const std::function<bool()>& shouldAbort = {});
 
 /** Analyses a file with the standard level/spectrum/envelope analysers.
     Level stats: sample peak, oversampled true peak, RMS, EBU R128 loudness

--- a/modules/tracktion_engine/audio_files/tracktion_AudioFileAnalyser.test.cpp
+++ b/modules/tracktion_engine/audio_files/tracktion_AudioFileAnalyser.test.cpp
@@ -269,6 +269,21 @@ TEST_SUITE ("tracktion_engine")
                                             AudioAnalysisOptions());
             CHECK (! result.has_value());
         }
+
+        SUBCASE ("an aborted analysis fails rather than returning partial results")
+        {
+            juce::TemporaryFile file (".wav");
+            writeTestFile<juce::WavAudioFormat> (file.getFile(), 44100.0, 1, 4 * 44100, 32, [] (int, int i)
+            {
+                return 0.5f * std::sin (juce::MathConstants<float>::twoPi * 220.0f * (float) i / 44100.0f);
+            });
+
+            AudioAnalysisOptions options;
+            options.shouldAbort = [] { return true; };
+
+            auto result = analyseAudioFile (*Engine::getEngines()[0], file.getFile(), options);
+            CHECK (! result.has_value());
+        }
     }
 }
 


### PR DESCRIPTION
Adds `AudioAnalysisOptions::shouldAbort`, checked between read blocks as the file streams, so a caller's worker thread can shut down promptly part-way through a long file instead of waiting for the whole analysis (or being force-killed after a timeout, which can strand a lock that later hangs shutdown). An aborted analysis returns an error rather than partial results.

- `shouldAbort` field on `AudioAnalysisOptions`, plus a matching parameter on the raw-analysers overload
- Checked once per 64k-sample block in the read loop
- Unit test: an analysis whose callback aborts immediately fails rather than returning results

Waveform's render-dialog loudness analyser is the first caller: it passes `threadShouldExit` so closing the dialog stops a long measurement mid-file. TestRunner passes (19029 assertions).