### PR TITLE
Fix SoundTouch producing silence through the read-ahead time-stretch path

### DIFF
--- a/modules/tracktion_engine/playback/graph/tracktion_WaveNode.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_WaveNode.cpp
@@ -717,8 +717,9 @@ public:
             inputFifo.write (scratchBuffer.buffer);
         }
 
+        // N.B. processData only ever writes up to chunkSize frames to the output FIFO
+        // so that's all the space that needs to be free, not numThisTime
         assert (inputFifo.getNumReady() >= numThisTime);
-        assert (outputFifo.getFreeSpace() >= numThisTime);
         assert (outputFifo.getFreeSpace() >= chunkSize);
         timeStretcher.processData (inputFifo, numThisTime, outputFifo);
 

--- a/modules/tracktion_engine/playback/graph/tracktion_WaveNode.test.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_WaveNode.test.cpp
@@ -378,8 +378,9 @@ namespace wavenode_test_helpers
         };
 
         for (auto mode : syncTestModes)
+        for (auto readAhead : { WaveNodeRealTime::ReadAhead::no, WaveNodeRealTime::ReadAhead::yes })
         {
-            MESSAGE (magic_enum::enum_name (mode));
+            MESSAGE (magic_enum::enum_name (mode) << (readAhead == WaveNodeRealTime::ReadAhead::yes ? std::string_view (", read-ahead") : std::string_view()));
             auto node = std::make_unique<WaveNodeRealTime> (squareAudioFile,
                                                             TimeRange (1_tp, fileLength),
                                                             0_td,
@@ -394,7 +395,10 @@ namespace wavenode_test_helpers
                                                             ResamplingQuality::lagrange,
                                                             SpeedFadeDescription(),
                                                             std::nullopt,
-                                                            mode);
+                                                            mode,
+                                                            TimeStretcher::ElastiqueProOptions(),
+                                                            0.0f,
+                                                            readAhead);
 
             auto testContext = createTracktionTestContext (processState, std::move (node), ts, 1, (fileLength * 3.0).inSeconds());
 
@@ -445,8 +449,9 @@ TEST_CASE ("WaveNode")
 
 #endif
 
-// Currently only works with RubberBand
-#if ENGINE_UNIT_TESTS_WAVENODE_READAHEAD && TRACKTION_ENABLE_TIMESTRETCH_RUBBERBAND
+#if ENGINE_UNIT_TESTS_WAVENODE_READAHEAD \
+    && (TRACKTION_ENABLE_TIMESTRETCH_RUBBERBAND || TRACKTION_ENABLE_TIMESTRETCH_SOUNDTOUCH \
+        || TRACKTION_ENABLE_TIMESTRETCH_SIGNALSMITH || TRACKTION_ENABLE_TIMESTRETCH_ELASTIQUE)
 TEST_SUITE("tracktion_engine")
 {
     TEST_CASE ("Playback single audio clip using read-ahead")

--- a/modules/tracktion_engine/timestretch/tracktion_TimeStretch.cpp
+++ b/modules/tracktion_engine/timestretch/tracktion_TimeStretch.cpp
@@ -499,16 +499,31 @@ struct SoundTouchStretcher  : public TimeStretcher::Stretcher,
             setSetting (SETTING_SEQUENCE_MS, 60);
             setSetting (SETTING_SEEKWINDOW_MS, 25);
         }
+
+        // SoundTouch buffers its initial latency worth of input before it emits anything and
+        // that latency grows with the tempo, so size the maximum for the slowest supported
+        // speed (0.25, i.e. tempo 4) plus one block's worth of input at the fastest (4)
+        setTempo (1.0f / minSupportedSpeedRatio);
+        maxFramesNeeded = getSetting (SETTING_INITIAL_LATENCY)
+                            + juce::roundToInt (samplesPerOutputBuffer * maxSupportedSpeedRatio);
+        setTempo (1.0f);
+        initialLatency = getSetting (SETTING_INITIAL_LATENCY);
     }
 
     bool isOk() const override      { return true; }
-    void reset() override           { clear(); }
+
+    void reset() override
+    {
+        clear();
+        hasProducedOutput = false;
+    }
 
     bool setSpeedAndPitch (float speedRatio, float semitonesUp) override
     {
         setTempo (1.0f / speedRatio);
         setPitchSemiTones (semitonesUp);
         inputOutputSampleRatio = getInputOutputSampleRatio();
+        initialLatency = getSetting (SETTING_INITIAL_LATENCY);
 
         return true;
     }
@@ -517,14 +532,23 @@ struct SoundTouchStretcher  : public TimeStretcher::Stretcher,
     {
         const int numAvailable = (int) numSamples();
         const int numRequiredForOneBlock = juce::roundToInt (samplesPerOutputBuffer * inputOutputSampleRatio);
+        const int numRequiredForOutput = std::max (0, numRequiredForOneBlock - numAvailable);
 
-        return std::max (0, numRequiredForOneBlock - numAvailable);
+        if (hasProducedOutput || numAvailable > 0)
+            return numRequiredForOutput;
+
+        // Until the first batch has been produced, SoundTouch needs its initial latency
+        // worth of input buffered before it will emit anything, so ask for enough to get
+        // the first block out in one go rather than reporting a single block's worth and
+        // returning nothing from processData for several calls
+        const int numToPrime = initialLatency + numRequiredForOneBlock - (int) numUnprocessedSamples();
+
+        return juce::jlimit (0, maxFramesNeeded, std::max (numRequiredForOutput, numToPrime));
     }
 
     int getMaxFramesNeeded() const override
     {
-        // This was derived by experimentation
-        return 8192;
+        return maxFramesNeeded;
     }
 
     int processData (const float* const* inChannels, int numSamples, float* const* outChannels) override
@@ -539,7 +563,10 @@ struct SoundTouchStretcher  : public TimeStretcher::Stretcher,
         const int numToRead = std::min (numAvailable, samplesPerOutputBuffer);
 
         if (numToRead > 0)
+        {
+            hasProducedOutput = true;
             return readOutput (outChannels, 0, numToRead);
+        }
 
         return 0;
     }
@@ -560,8 +587,13 @@ struct SoundTouchStretcher  : public TimeStretcher::Stretcher,
     }
 
 private:
+    // Speed ratios outside this range still work but getFramesNeeded is clamped to
+    // getMaxFramesNeeded so the first block may take more than one process call
+    static constexpr float minSupportedSpeedRatio = 0.25f, maxSupportedSpeedRatio = 4.0f;
+
     int numChannels = 0, samplesPerOutputBuffer = 0;
-    bool hasDoneFinalBlock = false;
+    int maxFramesNeeded = 0, initialLatency = 0;
+    bool hasDoneFinalBlock = false, hasProducedOutput = false;
     double inputOutputSampleRatio = 1.0;
 
     int readOutput (float* const* outChannels, int offset, int numNeeded)

--- a/modules/tracktion_engine/timestretch/tracktion_TimeStretch.h
+++ b/modules/tracktion_engine/timestretch/tracktion_TimeStretch.h
@@ -144,6 +144,9 @@ public:
 
     /** Returns the expected number of frames required to generate some output.
         This should be queried each block and the returned number of frames be passes to processData.
+        Passing this many frames to processData must always produce at least one block of output,
+        including the first call after a reset, so implementations account for any internal
+        buffering their algorithm needs before it emits. This never exceeds getMaxFramesNeeded.
     */
     int getFramesNeeded() const;
 

--- a/modules/tracktion_engine/timestretch/tracktion_TimeStretch.test.cpp
+++ b/modules/tracktion_engine/timestretch/tracktion_TimeStretch.test.cpp
@@ -324,6 +324,46 @@ void runSmallBlockLatencyTest (tracktion::engine::TimeStretcher::Mode mode)
     CHECK (maxFrames >= stretcher.getLatencySamples());
 }
 
+// getFramesNeeded() must report enough frames to get at least one block out of processData,
+// including the very first call after initialisation or a reset, and must never exceed
+// getMaxFramesNeeded() so callers can size their FIFOs from it
+void runFramesNeededContractTest (tracktion::engine::TimeStretcher::Mode mode)
+{
+    for (double sampleRate : { 44100.0, 96000.0 })
+    for (int blockSize : { 64, 512 })
+    for (auto [speedRatio, semitones] : { std::pair { 1.0f, 0.0f }, std::pair { 0.5f, 0.0f }, std::pair { 2.0f, 0.0f },
+                                          std::pair { 1.0f, 12.0f }, std::pair { 1.0f, -12.0f } })
+    {
+        CAPTURE (sampleRate); CAPTURE (blockSize); CAPTURE (speedRatio); CAPTURE (semitones);
+
+        const int numChannels = 2;
+        tracktion::engine::TimeStretcher stretcher;
+        stretcher.initialise (sampleRate, blockSize, numChannels, mode, {}, true);
+        stretcher.setSpeedAndPitch (speedRatio, semitones);
+
+        const int maxFramesNeeded = stretcher.getMaxFramesNeeded();
+        const auto source = createSinBuffer (sampleRate, numChannels, 440.0f);
+        juce::AudioBuffer<float> output (numChannels, blockSize);
+
+        auto pushFramesNeededOnce = [&]
+        {
+            const int framesNeeded = stretcher.getFramesNeeded();
+            CHECK (framesNeeded > 0);
+            CHECK (framesNeeded <= maxFramesNeeded);
+            REQUIRE (framesNeeded <= source.getNumSamples());
+
+            return stretcher.processData (source.getArrayOfReadPointers(), framesNeeded,
+                                          output.getArrayOfWritePointers());
+        };
+
+        CHECK (pushFramesNeededOnce() > 0);
+
+        stretcher.reset();
+        stretcher.setSpeedAndPitch (speedRatio, semitones);
+        CHECK (pushFramesNeededOnce() > 0);
+    }
+}
+
 } // anonymous namespace
 
 TEST_SUITE ("tracktion_engine")
@@ -337,6 +377,7 @@ TEST_SUITE ("tracktion_engine")
             runPitchShiftTest (mode);
             runTimestretchTest (mode);
             runLatencyTest (mode);
+            runFramesNeededContractTest (mode);
         }
        #endif
 
@@ -347,6 +388,7 @@ TEST_SUITE ("tracktion_engine")
             runPitchShiftTest (mode);
             runTimestretchTest (mode);
             runLatencyTest (mode);
+            runFramesNeededContractTest (mode);
         }
        #endif
 
@@ -358,6 +400,7 @@ TEST_SUITE ("tracktion_engine")
             runTimestretchTest (mode);
             runLatencyTest (mode);
             runSmallBlockLatencyTest (mode);
+            runFramesNeededContractTest (mode);
         }
        #endif
 


### PR DESCRIPTION
## Problem

`TimeStretcher::Mode::soundtouchBetter` produces completely silent output when used via `WaveNodeRealTime::ReadAhead::yes`, i.e. whenever a host returns `true` from `EngineBehaviour::enableReadAheadForTimeStretchNodes()` (as the TestRunner does). RMS is exactly 0 across the whole buffer, at every sample rate. Without read-ahead SoundTouch works and is well aligned.

## Cause

`SoundTouchStretcher::getFramesNeeded()` did not honour its contract. SoundTouch buffers its initial latency worth of input before it emits anything, but `getFramesNeeded()` only ever reported one block's worth (`samplesPerBlock * ioRatio`, 256-2048 frames). Measured input needed before the first output for the "better" settings:

| Sample rate | Speed ratio | Frames before first output | `SETTING_INITIAL_LATENCY` |
| --- | --- | --- | --- |
| 44100 | 1.0 | 4096 | 3812 |
| 44100 | 0.5 | 6144 | 6106 |
| 96000 | 1.0 | 8704 | 8224 |
| 96000 | 0.5 | 13312 | 13216 |

So the first `processData` call after a reset returned 0 frames. The non-read-ahead `TimeStretchReader` loops until output appears and hides this; `ReadAheadTimeStretchReader` pushes `getFramesNeeded()` frames, pops one block, and treats an empty pop as end-of-data, so playback stayed silent. The hard-coded `getMaxFramesNeeded() == 8192` was also wrong: at 96 kHz the priming requirement exceeds it.

## Fix

Make `SoundTouchStretcher` report what SoundTouch actually needs, following the pattern `RubberBandStretcher` already uses while priming:

- `getFramesNeeded()`: until the first batch has been produced since the last reset, return `SETTING_INITIAL_LATENCY + one block's input - numUnprocessedSamples()`, clamped to `getMaxFramesNeeded()`. Afterwards the existing per-block formula applies. A `hasProducedOutput` flag (cleared in `reset()`) tracks this.
- `getMaxFramesNeeded()`: computed once in the constructor from `SETTING_INITIAL_LATENCY` at the slowest supported speed (0.25, tempo 4) plus a block's input at the fastest (4), so it is sample-rate aware rather than a magic number. Speed ratios outside 0.25-4 still work but may need more than one process call for the first block.
- `SETTING_INITIAL_LATENCY` is re-read in `setSpeedAndPitch` since it depends on tempo/rate.

No reader changes are needed. `TimeStretchReader` loses its `assert (outputFifo.getFreeSpace() >= numThisTime)`, which compared output space against an *input* count - `processData` only writes up to `chunkSize` frames, which the next assertion already covers, and it fires as soon as RubberBand's 8192-frame priming request coincides with queued output.

`TimeStretcher::getFramesNeeded()` docs now state the contract: this many frames must yield at least one block, including the first call after a reset, and never exceed `getMaxFramesNeeded()`.

## Tests

- New `runFramesNeededContractTest` in `tracktion_TimeStretch.test.cpp`: for 44.1/96 kHz x 64/512 block x five speed/pitch combinations, pushing exactly `getFramesNeeded()` frames once must produce output, both straight after initialisation and again after `reset()`, and `getFramesNeeded() <= getMaxFramesNeeded()` throughout. Run for SoundTouch, RubberBand and Signalsmith.
- The `syncTestModes` latency-compensation block in `runTimestretchedTests()` now runs every enabled algorithm against both `ReadAhead::no` and `ReadAhead::yes`.
- `Playback single audio clip using read-ahead` guard relaxed from RubberBand-only to any enabled algorithm.

Verified locally on macOS (Debug, RubberBand + Signalsmith + SoundTouch):

- `--source-file="*TimeStretch.test.cpp"`: 542/542 assertions (was 62 before the contract test).
- `--source-file="*WaveNode.test.cpp"`: 3/3 cases, 1118/1118 assertions; all three algorithms run 8 setups x both read-ahead modes.
- With only the `SoundTouchStretcher` change reverted: 40 contract assertions fail (every SoundTouch combination, first push and post-reset push) and the 8 `soundtouchBetter, read-ahead` WaveNode cases fail with `rms == 0` - the reported symptom. RubberBand and Signalsmith pass the contract unchanged.
