### PR TITLE
Oscillators: Fixed the data race on the static juce::Random shared by start()

### DIFF
--- a/modules/tracktion_core/tracktion_TestConfig.h
+++ b/modules/tracktion_core/tracktion_TestConfig.h
@@ -49,6 +49,7 @@
 #define ENGINE_UNIT_TESTS_LOOP_INFO                     1
 #define ENGINE_UNIT_TESTS_MIDILIST                      1
 #define ENGINE_UNIT_TESTS_MODIFIERS                     1
+#define ENGINE_UNIT_TESTS_OSCILLATORS                   1
 #define ENGINE_UNIT_TESTS_PAN_LAW                       1
 #define ENGINE_UNIT_TESTS_PATCHBAY                     1
 #define ENGINE_UNIT_TESTS_PLAYBACK                      1

--- a/modules/tracktion_engine/tracktion_engine_utils.cpp
+++ b/modules/tracktion_engine/tracktion_engine_utils.cpp
@@ -79,6 +79,7 @@ extern "C" char MacGetMacFSRefForREXDLL (FSRef* fsRef)
 #include "utilities/tracktion_Envelope.cpp"
 #include "utilities/tracktion_FileUtilities.cpp"
 #include "utilities/tracktion_Oscillators.cpp"
+#include "utilities/tracktion_Oscillators.test.cpp"
 #include "utilities/tracktion_PropertyStorage.cpp"
 #include "utilities/tracktion_ParameterHelpers.cpp"
 #include "utilities/tracktion_UIBehaviour.cpp"

--- a/modules/tracktion_engine/utilities/tracktion_Oscillators.cpp
+++ b/modules/tracktion_engine/utilities/tracktion_Oscillators.cpp
@@ -60,8 +60,7 @@ static float sawDown (float phase, float freq, double sampleRate)
 //==============================================================================
 void Oscillator::start()
 {
-    static juce::Random r;
-    phase = r.nextFloat();
+    phase = random.nextFloat();
 }
 
 void Oscillator::setSampleRate (double sr)
@@ -203,11 +202,9 @@ MultiVoiceOscillator::MultiVoiceOscillator (int maxVoices)
 
 void MultiVoiceOscillator::start()
 {
-    static juce::Random r;
-
     for (int i = 0; i < oscillators.size(); i += 2)
     {
-        float phase = r.nextFloat();
+        const float phase = random.nextFloat();
         oscillators[i + 0]->start (phase);
         oscillators[i + 1]->start (phase);
     }

--- a/modules/tracktion_engine/utilities/tracktion_Oscillators.h
+++ b/modules/tracktion_engine/utilities/tracktion_Oscillators.h
@@ -77,6 +77,7 @@ private:
 
     BandlimitedWaveLookupTables::Ptr lookupTables;
 
+    juce::Random random;
     std::default_random_engine generator;
     std::normal_distribution<float> normalDistribution {0.0f, 0.1f};
 };
@@ -103,6 +104,7 @@ public:
 
 private:
     juce::OwnedArray<Oscillator> oscillators;
+    juce::Random random;
 
     int voices = 1;
     float detune = 0, spread = 0, gain = 1.0f, note = 69.0f, pan = 0.0f;

--- a/modules/tracktion_engine/utilities/tracktion_Oscillators.test.cpp
+++ b/modules/tracktion_engine/utilities/tracktion_Oscillators.test.cpp
@@ -1,0 +1,153 @@
+/*
+    ,--.                     ,--.     ,--.  ,--.
+  ,-'  '-.,--.--.,--,--.,---.|  |,-.,-'  '-.`--' ,---. ,--,--,      Copyright 2024
+  '-.  .-'|  .--' ,-.  | .--'|     /'-.  .-',--.| .-. ||      \   Tracktion Software
+    |  |  |  |  \ '-'  \ `--.|  \  \  |  |  |  |' '-' '|  ||  |       Corporation
+    `---' `--'   `--`--'`---'`--'`--' `---' `--' `---' `--''--'    www.tracktion.com
+
+    Tracktion Engine uses a GPL/commercial licence - see LICENCE.md for details.
+*/
+
+#if TRACKTION_UNIT_TESTS && ENGINE_UNIT_TESTS_OSCILLATORS
+
+#include <tracktion_engine/../3rd_party/doctest/tracktion_doctest.hpp>
+
+#include <atomic>
+#include <set>
+#include <thread>
+#include <vector>
+
+namespace tracktion { inline namespace engine
+{
+
+TEST_SUITE ("tracktion_engine")
+{
+    //==============================================================================
+    static float getFirstSample (Oscillator& o)
+    {
+        juce::AudioBuffer<float> buffer (1, 1);
+        buffer.clear();
+        o.process (buffer, 0, 1);
+        return buffer.getSample (0, 0);
+    }
+
+    static float getFirstSample (MultiVoiceOscillator& o)
+    {
+        juce::AudioBuffer<float> buffer (2, 1);
+        buffer.clear();
+        o.process (buffer, 0, 1);
+        return buffer.getSample (0, 0);
+    }
+
+    template<typename OscillatorType>
+    static OscillatorType createOscillator();
+
+    template<>
+    Oscillator createOscillator<Oscillator>()                     { return {}; }
+
+    template<>
+    MultiVoiceOscillator createOscillator<MultiVoiceOscillator>()  { return MultiVoiceOscillator (1); }
+
+    template<typename OscillatorType>
+    static std::set<float> getFirstSamplesAfterRepeatedStarts (int numStarts)
+    {
+        auto o = createOscillator<OscillatorType>();
+        o.setSampleRate (44100.0);
+        o.setWave (Oscillator::sine);
+
+        std::set<float> firstSamples;
+
+        for (int i = 0; i < numStarts; ++i)
+        {
+            o.start();
+            firstSamples.insert (getFirstSample (o));
+        }
+
+        return firstSamples;
+    }
+
+    template<typename OscillatorType>
+    static std::set<float> getFirstSamplesOfFreshInstances (int numInstances)
+    {
+        std::set<float> firstSamples;
+
+        for (int i = 0; i < numInstances; ++i)
+        {
+            auto o = createOscillator<OscillatorType>();
+            o.setSampleRate (44100.0);
+            o.setWave (Oscillator::sine);
+            o.start();
+            firstSamples.insert (getFirstSample (o));
+        }
+
+        return firstSamples;
+    }
+
+    //==============================================================================
+    TEST_CASE ("Oscillators: start() picks a random phase")
+    {
+        // Each start() should draw a new phase, and each instance should seed
+        // its own generator so fresh instances don't all start from the same phase.
+        // Instance counts are kept low as each setSampleRate() builds a fresh set
+        // of bandlimited lookup tables, which is slow in Debug builds
+        SUBCASE ("Oscillator")
+        {
+            CHECK (getFirstSamplesAfterRepeatedStarts<Oscillator> (8).size() > 1);
+            CHECK (getFirstSamplesOfFreshInstances<Oscillator> (4).size() > 1);
+        }
+
+        SUBCASE ("MultiVoiceOscillator")
+        {
+            CHECK (getFirstSamplesAfterRepeatedStarts<MultiVoiceOscillator> (8).size() > 1);
+            CHECK (getFirstSamplesOfFreshInstances<MultiVoiceOscillator> (4).size() > 1);
+        }
+    }
+
+    TEST_CASE ("Oscillators: start() on separate instances from concurrent threads")
+    {
+        // Regression test for #400. start() used to draw its phase from a
+        // function-local static juce::Random shared by every instance in the
+        // process, so voices started at the same time on different audio threads
+        // raced on its seed. Each thread here owns its own oscillators so nothing
+        // should be shared between them. The race is silent without
+        // ThreadSanitizer, which CI runs this under.
+        constexpr int numThreads = 8;
+        constexpr int numStarts = 1000;
+
+        std::atomic<int> numReady { 0 };
+        std::vector<int> numStartsCompleted ((size_t) numThreads, 0);
+        std::vector<std::thread> threads;
+
+        for (int t = 0; t < numThreads; ++t)
+        {
+            threads.emplace_back ([&, t]
+            {
+                MultiVoiceOscillator multi;
+                Oscillator single;
+
+                ++numReady;
+
+                while (numReady < numThreads)
+                    std::this_thread::yield();
+
+                for (int i = 0; i < numStarts; ++i)
+                {
+                    multi.start();
+                    single.start();
+                }
+
+                numStartsCompleted[(size_t) t] = numStarts;
+            });
+        }
+
+        for (auto& t : threads)
+            t.join();
+
+        for (auto n : numStartsCompleted)
+            CHECK_EQ (n, numStarts);
+    }
+}
+
+}} // namespace tracktion { inline namespace engine
+
+#endif // ENGINE_UNIT_TESTS_OSCILLATORS


### PR DESCRIPTION
## Summary
`Oscillator::start()` and `MultiVoiceOscillator::start()` each drew their random start phase from a function-local `static juce::Random`. Each oscillator now owns a `juce::Random` member instead, so starting a note only touches state belonging to that instance. Behaviour is unchanged: every note still gets a random start phase, and `juce::Random`'s default constructor seeds itself, so instances don't share a sequence.

## Root cause
The static generator was shared by every oscillator in the process and is entered from the audio thread: `FourOscVoice::noteStarted()` calls `MultiVoiceOscillator::start()` on each of its four oscillators from within `renderNextBlock`, on new notes and on retrigger. With more than one audio worker thread (the default is the CPU count), two 4OSC instances on different tracks starting notes at the same time race on `juce::Random`'s seed, which is not thread safe. `Oscillator::start()` is not called from within the engine but is public API and had the same construction, so it gets the same fix.

Cost is one `juce::Random` (16 bytes) per `Oscillator` and per `MultiVoiceOscillator`.

## Regression test
New `tracktion_Oscillators.test.cpp` (enabled via `ENGINE_UNIT_TESTS_OSCILLATORS`):
- "start() on separate instances from concurrent threads": eight threads each own a `MultiVoiceOscillator` and an `Oscillator` and call `start()` repeatedly at the same time. Nothing should be shared between them. The race is silent without ThreadSanitizer, so this case is aimed at the TSan CI job. Verified locally with a `-fsanitize=thread` Debug build: before the fix TSan reports 4 data races in `juce::Random::nextInt()` via both `start()` overloads and the run exits 134; after the fix the run is clean.
- "start() picks a random phase": checks that repeated `start()` calls on one instance, and `start()` on freshly constructed instances, produce different first samples. This guards against regressing to a fixed or default-seeded generator (e.g. reusing the `std::default_random_engine` the noise path already owns, which would give every instance the same phase sequence).

Full Debug `TestRunner` run locally: all JUCE unit tests pass; the only doctest failures are two pre-existing `ClipLauncher` audio-clip cases that fail identically on a develop baseline build on this machine while develop CI is green.

Fixes #400