### PR TITLE
Testing: Removed the SoundTouch read-ahead skip from the stretcher alignment test

### DIFF
--- a/modules/tracktion_engine/playback/graph/tracktion_WaveNode.test.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_WaveNode.test.cpp
@@ -447,11 +447,6 @@ namespace wavenode_test_helpers
             {
                 for (auto readAhead : { WaveNodeRealTime::ReadAhead::no, WaveNodeRealTime::ReadAhead::yes })
                 {
-                    // Read-ahead doesn't currently support every algorithm, SoundTouch
-                    // produces no output at all through it
-                    if (readAhead == WaveNodeRealTime::ReadAhead::yes && mode == TimeStretcher::Mode::soundtouchBetter)
-                        continue;
-
                     // Each entry is the clip's source offset and the sections of the timeline
                     // that must then be audible, the clip always starting at 1s
                     const std::pair<TimeDuration, std::array<bool, 3>> offsetsAndExpectedSections[] =


### PR DESCRIPTION
Follow-up to #404. The alignment test in `runTimestretchedTests()` skipped SoundTouch through the read-ahead reader because it produced no output at that point. `5cfdac4b7cd` fixed that, so the skip is now dead code hiding SoundTouch read-ahead alignment coverage.

Commit is `[skip ci]` and the branch is `_quick` by request - intended to be force-merged.