### PR TITLE
RenderQueue: Made job progress and state safe to poll from any thread

### DIFF
--- a/modules/tracktion_engine/model/export/tracktion_RenderQueue.cpp
+++ b/modules/tracktion_engine/model/export/tracktion_RenderQueue.cpp
@@ -41,15 +41,34 @@ ScopedTrackMuter::~ScopedTrackMuter()
 }
 
 //==============================================================================
+std::shared_ptr<EditRenderer::Handle> RenderQueue::Job::getHandle() const
+{
+    const std::lock_guard lock (handleMutex);
+    return handle;
+}
+
+std::shared_ptr<EditRenderer::Handle> RenderQueue::Job::setHandle (std::shared_ptr<EditRenderer::Handle> newHandle)
+{
+    std::shared_ptr<EditRenderer::Handle> previous;
+
+    {
+        const std::lock_guard lock (handleMutex);
+        previous = std::exchange (handle, std::move (newHandle));
+    }
+
+    // Returned rather than dropped here: releasing the last reference joins the
+    // render thread, which must not happen while the lock is held
+    return previous;
+}
+
 float RenderQueue::Job::getProgress() const
 {
-    TRACKTION_ASSERT_MESSAGE_THREAD
-
+    // Deliberately callable from any thread - see the header
     if (state == State::completed)
         return 1.0f;
 
-    if (handle != nullptr)
-        return handle->getProgress();
+    if (auto h = getHandle())
+        return h->getProgress();
 
     return 0.0f;
 }
@@ -66,8 +85,8 @@ void RenderQueue::Job::cancel()
     {
         state = State::cancelled;
 
-        if (handle != nullptr)
-            handle->cancel();
+        if (auto h = getHandle())
+            h->cancel();
     }
 }
 
@@ -91,9 +110,9 @@ RenderQueue::~RenderQueue()
     // would throw away a complete file.
     for (auto& job : jobs)
     {
-        if (job->handle != nullptr)
+        if (auto h = job->setHandle (nullptr))
         {
-            job->handle = nullptr;   // joins the render thread, so renderSucceeded has settled
+            h.reset();   // joins the render thread, so renderSucceeded has settled
 
             if (! job->renderSucceeded)
                 job->planned.params.destFile.deleteFile();
@@ -125,7 +144,7 @@ void RenderQueue::start()
     // If a job is running (or its finished callback is still in flight), the
     // queue will advance itself; starting another job now would run two at once
     for (auto& job : jobs)
-        if (job->state == Job::State::active || job->handle != nullptr)
+        if (job->state == Job::State::active || job->getHandle() != nullptr)
             return;
 
     startNextJob();
@@ -218,18 +237,18 @@ void RenderQueue::startNextJob()
         // The finished callback arrives on the render thread, so hop back to the
         // message thread. The job pointer keeps the Job alive; the alive flag
         // skips advancing the queue if the queue itself has gone.
-        job.handle = EditRenderer::render (job.planned.params,
-                                           [alive = std::weak_ptr<bool> (aliveFlag), this, jobPtr] (auto renderResult)
-                                           {
-                                               jobPtr->renderSucceeded = renderResult.has_value();
+        job.setHandle (EditRenderer::render (job.planned.params,
+                                             [alive = std::weak_ptr<bool> (aliveFlag), this, jobPtr] (auto renderResult)
+                                             {
+                                                 jobPtr->renderSucceeded = renderResult.has_value();
 
-                                               juce::MessageManager::callAsync ([alive, this, jobPtr, result = std::move (renderResult)]() mutable
-                                               {
-                                                   if (auto stillAlive = alive.lock(); stillAlive != nullptr && *stillAlive)
-                                                       handleJobFinished (*jobPtr, std::move (result));
-                                               });
-                                           },
-                                           job.thumbnail);
+                                                 juce::MessageManager::callAsync ([alive, this, jobPtr, result = std::move (renderResult)]() mutable
+                                                 {
+                                                     if (auto stillAlive = alive.lock(); stillAlive != nullptr && *stillAlive)
+                                                         handleJobFinished (*jobPtr, std::move (result));
+                                                 });
+                                             },
+                                             job.thumbnail));
         return;
     }
 
@@ -240,7 +259,10 @@ void RenderQueue::startNextJob()
 void RenderQueue::handleJobFinished (Job& job, tl::expected<juce::File, std::string> result)
 {
     TRACKTION_ASSERT_MESSAGE_THREAD
-    job.handle = nullptr;
+
+    // Released here rather than inside setHandle, but still on the message thread
+    // and at the same point in the sequence as before
+    job.setHandle (nullptr).reset();
     job.muteScope.reset();
 
     // A job cancelled while active has already been marked cancelled

--- a/modules/tracktion_engine/model/export/tracktion_RenderQueue.h
+++ b/modules/tracktion_engine/model/export/tracktion_RenderQueue.h
@@ -69,13 +69,20 @@ public:
         };
 
         //==============================================================================
+        /** This job's state. Safe to call from any thread. */
         State getState() const                                  { return state; }
         juce::String getName() const                            { return planned.name; }
 
         /** The parameters this job renders with. */
         const Renderer::Parameters& getParameters() const       { return planned.params; }
 
-        /** Returns this job's progress, 0 to 1. */
+        /** Returns this job's progress, 0 to 1.
+
+            Safe to call from any thread: the render already writes its progress to
+            an atomic, and the handle holding it is published under a lock. Polling
+            this is the supported way to follow a render from a thread that is
+            blocked waiting for it, which is what a background script does.
+        */
         float getProgress() const;
 
         /** Returns the rendered file once the job has completed. */
@@ -103,11 +110,26 @@ public:
         explicit Job (PlannedRenderJob p) : planned (std::move (p)) {}
 
         PlannedRenderJob planned;
-        State state = State::pending;
+
+        // Atomic so getState()/getProgress() can be polled while the message
+        // thread advances the queue
+        std::atomic<State> state { State::pending };
+
         juce::File resultFile;
         juce::String error;
         std::shared_ptr<juce::AudioFormatWriter::ThreadedWriter::IncomingDataReceiver> thumbnail;
+
+        /** Guards handle for the same reason. Only ever held long enough to copy
+            the pointer - never while a handle is released, because that joins the
+            render thread and would stall any thread polling progress. */
+        mutable std::mutex handleMutex;
         std::shared_ptr<EditRenderer::Handle> handle;
+
+        std::shared_ptr<EditRenderer::Handle> getHandle() const;
+
+        /** Publishes a new handle and returns the old one, for the caller to
+            release where it chooses. Never releases it under the lock. */
+        std::shared_ptr<EditRenderer::Handle> setHandle (std::shared_ptr<EditRenderer::Handle>);
 
         /** Set on the render thread the moment the render returns, before the
             message-thread hop that updates state. ~RenderQueue can run in between
@@ -157,7 +179,11 @@ public:
     /** Returns true once every job has completed, failed or been cancelled. */
     bool hasFinished() const;
 
-    /** Returns the overall progress of the queue, 0 to 1. */
+    /** Returns the overall progress of the queue, 0 to 1.
+        Message thread only - it walks the job list, which the message thread may
+        append to at any time. To follow a queue from another thread, keep the
+        JobPtrs you care about and poll Job::getProgress(), which is thread safe.
+    */
     float getTotalProgress() const;
 
     //==============================================================================

--- a/modules/tracktion_engine/model/export/tracktion_RenderQueue.test.cpp
+++ b/modules/tracktion_engine/model/export/tracktion_RenderQueue.test.cpp
@@ -503,6 +503,77 @@ TEST_SUITE ("tracktion_engine")
             CHECK_LT (maxDiff, 0.001f);
         }
     }
+
+    TEST_CASE ("RenderQueue progress can be polled from another thread")
+    {
+        // A background script blocks its own thread waiting for a render, so it
+        // has to be able to follow the progress from there. Run under TSan to
+        // check the state/handle publication, not just that the numbers arrive.
+        auto& engine = *Engine::getEngines()[0];
+        auto edit = test_utilities::createTestEdit (engine, 1);
+
+        auto sinFile = graph::test_utilities::getSinFile<juce::WavAudioFormat> (44100.0, 5.0);
+
+        for (auto t : getAudioTracks (*edit))
+            insertWaveClip (*t, {}, sinFile->getFile(), { .time = { 0_tp, 5_tp } },
+                            DeleteExistingClips::no);
+
+        auto destDir = juce::File::createTempFile ({});
+        destDir.createDirectory();
+
+        RenderQueue queue;
+
+        for (auto& spec : createPerTrackSpecifications (*edit, {}, destDir))
+            queue.addJob (*createRenderJob (*edit, spec));
+
+        REQUIRE_EQ (queue.getJobs().size(), (size_t) 1);
+
+        auto job = queue.getJobs()[0];
+        std::atomic<bool> allFinished { false };
+        queue.onFinished = [&] { allFinished = true; };
+
+        // Poll from a second thread for the whole life of the render
+        std::atomic<bool> pollerShouldStop { false };
+        std::atomic<int> pollCount { 0 };
+        std::atomic<float> highestSeen { -1.0f };
+        std::atomic<bool> sawOutOfRange { false };
+
+        std::thread poller ([&]
+        {
+            while (! pollerShouldStop)
+            {
+                const auto p = job->getProgress();
+                [[maybe_unused]] const auto s = job->getState();
+
+                if (p < 0.0f || p > 1.0f)
+                    sawOutOfRange = true;
+
+                highestSeen = std::max (highestSeen.load(), p);
+                ++pollCount;
+
+                std::this_thread::sleep_for (std::chrono::milliseconds (1));
+            }
+        });
+
+        queue.start();
+        test_utilities::runDispatchLoopUntilTrue (allFinished);
+
+        pollerShouldStop = true;
+        poller.join();
+
+        CHECK (queue.hasFinished());
+        CHECK_GT (pollCount.load(), 0);
+        CHECK_FALSE (sawOutOfRange.load());
+
+        // The poller has to have seen real progress, not just the 0 it starts at
+        CHECK_GT (highestSeen.load(), 0.0f);
+
+        // And once the job is done, any thread sees it complete
+        CHECK_EQ (job->getState(), RenderQueue::Job::State::completed);
+        CHECK_EQ (job->getProgress(), 1.0f);
+
+        destDir.deleteRecursively();
+    }
 }
 
 } // namespace tracktion::inline engine


### PR DESCRIPTION
## What

`RenderQueue::Job::getProgress()` and `getState()` are now callable from any thread.

## Why

A caller blocked on a render from a background thread had no way to follow it. `getProgress()` asserted the message thread, and underneath that it read a plain `State` member and a plain `shared_ptr` that the message thread writes as the queue advances — a real data race, not just an over-strict assert.

This came up driving a render from Waveform's AI assistant: the script runs on a worker thread and blocks there waiting for the queue, so the one thread that wants progress was the one thread that couldn't ask for it.

## How

- `Job::state` is now `std::atomic<State>`.
- The handle is published under a mutex, held only long enough to copy the pointer.
- `setHandle` **returns** the previous handle rather than dropping it, because releasing the last reference joins the render thread — that must not happen under the lock. Handles are still released at exactly the same points on the message thread as before, so the sequencing is unchanged.
- `getTotalProgress()` stays message-thread only: it walks the job vector, which can be appended to at any time. Callers on other threads should keep the `JobPtr`s they care about and poll those.

## Testing

Adds `RenderQueue progress can be polled from another thread`, which polls a running job from a second thread for the life of the render.

Verified the test actually catches the regression rather than passing either way:

- **without** this change (assert removed so it runs): `WARNING: ThreadSanitizer: data race ... in RenderQueue::Job::getProgress()` at the `state` read
- **with** it: clean

Full `*RenderQueue*` suite: 11/11 pass, no TSan warnings.