### PR TITLE
Playback: Fixed proxy-file clips playing 2 samples late

### DIFF
--- a/modules/tracktion_engine/playback/graph/tracktion_SpeedRampWaveNode.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_SpeedRampWaveNode.cpp
@@ -19,6 +19,7 @@ struct SpeedRampWaveNode::PerChannelState
 
     juce::LagrangeInterpolator resampler;
     float lastSample = 0;
+    bool resamplerNeedsPriming = true;
 };
 
 
@@ -147,8 +148,10 @@ int64_t SpeedRampWaveNode::editTimeToFileSample (TimePosition editTime) const no
         jassert (speedFadeDescription.outTimeRange.containsInclusive (editTime));
     }
 
-    return (int64_t) ((editTime - (editPosition.getStart() - offset)).inSeconds()
-                       * originalSpeedRatio * audioFileSampleRate + 0.5);
+    // N.B. floor rather than truncate so times before the clip start (which happen when a
+    // block straddles it) round to the nearest sample like all the others
+    return (int64_t) std::floor ((editTime - (editPosition.getStart() - offset)).inSeconds()
+                                  * originalSpeedRatio * audioFileSampleRate + 0.5);
 }
 
 bool SpeedRampWaveNode::updateFileSampleRate()
@@ -201,14 +204,20 @@ void SpeedRampWaveNode::processSection (ProcessContext& pc, juce::Range<int64_t>
     auto numChannels = (choc::buffer::ChannelCount) destChannels.size();
     assert (pc.buffers.audio.getNumChannels() == numChannels);
 
-    AudioScratchBuffer fileData ((int) numChannels, numFileSamples + 2);
+    // The resampler's output lags its input by its base latency, so read that many extra
+    // frames and feed the resampler from that far in. After a reset, the skipped frames
+    // prime its history so the first output frame lines up with fileStart
+    constexpr int resamplerLatency = static_cast<int> (juce::LagrangeInterpolator::getBaseLatency());
+    const auto numFileSamplesToRead = numFileSamples + resamplerLatency + 2;
+
+    AudioScratchBuffer fileData ((int) numChannels, numFileSamplesToRead);
 
     uint32_t lastSampleFadeLength = 0;
 
     {
         SCOPED_REALTIME_CHECK
 
-        if (reader->readSamples (numFileSamples + 2, fileData.buffer, destChannels, 0,
+        if (reader->readSamples (numFileSamplesToRead, fileData.buffer, destChannels, 0,
                                  channelsToUse,
                                  isOfflineRender ? 5000 : 3))
         {
@@ -251,7 +260,14 @@ void SpeedRampWaveNode::processSection (ProcessContext& pc, juce::Range<int64_t>
             const auto dest = destBuffer.getChannel (channel).data.data;
 
             auto& state = *channelState.getUnchecked ((int) channel);
-            state.resampler.processAdding (ratio, src, dest, (int) numSamples, gains[channel & 1]);
+
+            if (std::exchange (state.resamplerNeedsPriming, false))
+            {
+                float discarded[resamplerLatency];
+                state.resampler.process (1.0, src, discarded, resamplerLatency);
+            }
+
+            state.resampler.processAdding (ratio, src + resamplerLatency, dest, (int) numSamples, gains[channel & 1]);
 
             if (lastSampleFadeLength > 0)
             {

--- a/modules/tracktion_engine/playback/graph/tracktion_WaveNode.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_WaveNode.cpp
@@ -1597,6 +1597,7 @@ struct WaveNode::PerChannelState
 
     juce::LagrangeInterpolator resampler;
     float lastSample = 0;
+    bool resamplerNeedsPriming = true;
 };
 
 
@@ -1703,8 +1704,10 @@ int64_t WaveNode::editPositionToFileSample (int64_t timelinePosition) const noex
 
 int64_t WaveNode::editTimeToFileSample (TimePosition editTime) const noexcept
 {
-    return (int64_t) ((editTime - toDuration (editPosition.getStart() - offset)).inSeconds()
-                       * originalSpeedRatio * audioFileSampleRate + 0.5);
+    // N.B. floor rather than truncate so times before the clip start (which happen when a
+    // block straddles it) round to the nearest sample like all the others
+    return (int64_t) std::floor ((editTime - toDuration (editPosition.getStart() - offset)).inSeconds()
+                                  * originalSpeedRatio * audioFileSampleRate + 0.5);
 }
 
 bool WaveNode::updateFileSampleRate()
@@ -1786,7 +1789,13 @@ void WaveNode::processSection (ProcessContext& pc, juce::Range<int64_t> timeline
     auto numChannels = (choc::buffer::ChannelCount) destChannels.size();
     assert (pc.buffers.audio.getNumChannels() == numChannels);
 
-    AudioScratchBuffer fileData ((int) numChannels, numFileSamples + 2);
+    // The resampler's output lags its input by its base latency, so read that many extra
+    // frames and feed the resampler from that far in. After a reset, the skipped frames
+    // prime its history so the first output frame lines up with fileStart
+    constexpr int resamplerLatency = static_cast<int> (juce::LagrangeInterpolator::getBaseLatency());
+    const auto numFileSamplesToRead = numFileSamples + resamplerLatency + 2;
+
+    AudioScratchBuffer fileData ((int) numChannels, numFileSamplesToRead);
 
     uint32_t lastSampleFadeLength = 0;
 
@@ -1794,7 +1803,7 @@ void WaveNode::processSection (ProcessContext& pc, juce::Range<int64_t> timeline
     {
         SCOPED_REALTIME_CHECK
 
-        if (reader->readSamples (numFileSamples + 2, fileData.buffer, destChannels, 0,
+        if (reader->readSamples (numFileSamplesToRead, fileData.buffer, destChannels, 0,
                                  sourceChannels,
                                  isOfflineRender ? 5000 : 3))
         {
@@ -1833,6 +1842,7 @@ void WaveNode::processSection (ProcessContext& pc, juce::Range<int64_t> timeline
         for (auto state : *channelState)
         {
             state->resampler.reset();
+            state->resamplerNeedsPriming = true;
             state->lastSample = 0.0;
         }
 
@@ -1866,7 +1876,14 @@ void WaveNode::processSection (ProcessContext& pc, juce::Range<int64_t> timeline
             const auto dest = destBuffer.getIterator (channel).sample;
 
             auto& state = *channelState->getUnchecked ((int) channel);
-            state.resampler.processAdding (ratio, src, dest, (int) numFrames, gains[channel & 1]);
+
+            if (std::exchange (state.resamplerNeedsPriming, false))
+            {
+                float discarded[resamplerLatency];
+                state.resampler.process (1.0, src, discarded, resamplerLatency);
+            }
+
+            state.resampler.processAdding (ratio, src + resamplerLatency, dest, (int) numFrames, gains[channel & 1]);
 
             if (lastSampleFadeLength > 0)
             {

--- a/modules/tracktion_engine/playback/graph/tracktion_WaveNode.test.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_WaveNode.test.cpp
@@ -499,6 +499,71 @@ namespace wavenode_test_helpers
             }
         }
     }
+
+    /** Checks the source lines up with the timeline to the sample, not just roughly.
+        Proxy-file clips play through a WaveNode, so any resampler latency it leaves
+        uncompensated shows up as a phase offset against the same file playing
+        elsewhere (e.g. a Clip FX Invert failing to null against its source).
+    */
+    template<typename NodeType>
+    static void runSampleAlignmentTests (graph::test_utilities::TestSetup ts)
+    {
+        using namespace tracktion::graph::test_utilities;
+        auto& engine = *Engine::getEngines()[0];
+
+        // Impulses at the first frame and part way through. The clip starts on a block
+        // boundary so the first frame checks the resampler has no history to flush
+        const choc::buffer::FrameCount impulseFrames[] = { 0, 1000 };
+        const auto numFileFrames = (choc::buffer::FrameCount) ts.sampleRate;
+        auto impulseBuffer = choc::buffer::createChannelArrayBuffer (1, numFileFrames,
+                                                                     [&] (auto, auto frame) -> float
+                                                                     {
+                                                                         return std::find (std::begin (impulseFrames), std::end (impulseFrames), frame)
+                                                                                  != std::end (impulseFrames) ? 1.0f : 0.0f;
+                                                                     });
+        auto impulseFile = writeToTemporaryFile<juce::WavAudioFormat> (impulseBuffer.getView(), ts.sampleRate);
+        AudioFile impulseAudioFile (engine, impulseFile->getFile());
+
+        tracktion::graph::PlayHead playHead;
+        tracktion::graph::PlayHeadState playHeadState (playHead);
+        ProcessState processState (playHeadState);
+        playHead.playSyncedToRange ({ 0, std::numeric_limits<int64_t>::max() });
+
+        const auto clipStartSample = (int) ts.blockSize * 10;
+        const auto clipStart = TimePosition::fromSamples (clipStartSample, ts.sampleRate);
+
+        auto node = makeNode<NodeType> (impulseAudioFile,
+                                        TimeRange (clipStart, 1_td),
+                                        TimeDuration(),
+                                        TimeRange(),
+                                        LiveClipLevel(),
+                                        1.0,
+                                        ChannelConfiguration::discreteChannels (impulseAudioFile.getNumChannels()),
+                                        ChannelConfiguration::discreteChannels (1),
+                                        processState,
+                                        EditItemID(),
+                                        true);
+
+        auto testContext = createTracktionTestContext (processState, std::move (node), ts, 1, 2.0);
+        auto& output = testContext->buffer;
+
+        CAPTURE (ts.sampleRate);
+        CAPTURE (ts.blockSize);
+        CAPTURE (ts.randomiseBlockSizes);
+
+        for (auto frame : impulseFrames)
+        {
+            CAPTURE (frame);
+            const auto outputFrame = clipStartSample + (int) frame;
+            CHECK (output.getSample (0, outputFrame) == doctest::Approx (1.0f).epsilon (0.001));
+
+            for (int delta : { -2, -1, 1, 2 })
+            {
+                CAPTURE (delta);
+                CHECK (std::abs (output.getSample (0, outputFrame + delta)) < 0.001f);
+            }
+        }
+    }
 } // namespace wavenode_test_helpers
 
 TEST_SUITE ("tracktion_engine")
@@ -513,6 +578,7 @@ TEST_CASE ("WaveNode")
         runBasicTests<WaveNode> ("WaveNode", ts, true);
         runBasicTests<WaveNode> ("WaveNode", ts, false);
         runLoopedTimelineTests<WaveNode> ("WaveNode", ts);
+        runSampleAlignmentTests<WaveNode> (ts);
     }
 
     MESSAGE ("WaveNodeRealTime");
@@ -522,6 +588,7 @@ TEST_CASE ("WaveNode")
         runBasicTests<WaveNodeRealTime> ("WaveNodeRealTime", ts, true);
         runBasicTests<WaveNodeRealTime> ("WaveNodeRealTime", ts, false);
         runLoopedTimelineTests<WaveNodeRealTime> ("WaveNodeRealTime", ts);
+        runSampleAlignmentTests<WaveNodeRealTime> (ts);
         runDynamicOffsetTests (ts);
         runTimestretchedTests (ts);
     }

--- a/modules/tracktion_engine/playback/graph/tracktion_WaveNode.test.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_WaveNode.test.cpp
@@ -500,6 +500,39 @@ namespace wavenode_test_helpers
         }
     }
 
+    /** Returns a one second file with a single full scale sample at each of the given frames. */
+    static std::unique_ptr<juce::TemporaryFile> createImpulseFile (graph::test_utilities::TestSetup ts,
+                                                                   const std::vector<choc::buffer::FrameCount>& impulseFrames)
+    {
+        using namespace tracktion::graph::test_utilities;
+        auto buffer = choc::buffer::createChannelArrayBuffer (1, (choc::buffer::FrameCount) ts.sampleRate,
+                                                              [&] (auto, auto frame) -> float
+                                                              {
+                                                                  return std::find (impulseFrames.begin(), impulseFrames.end(), frame)
+                                                                           != impulseFrames.end() ? 1.0f : 0.0f;
+                                                              });
+
+        return writeToTemporaryFile<juce::WavAudioFormat> (buffer.getView(), ts.sampleRate);
+    }
+
+    /** Checks each impulse landed on exactly the timeline sample it should have, with silence either side. */
+    static void expectImpulsesAt (const juce::AudioBuffer<float>& output, int clipStartSample,
+                                  const std::vector<choc::buffer::FrameCount>& impulseFrames)
+    {
+        for (auto frame : impulseFrames)
+        {
+            CAPTURE (frame);
+            const auto outputFrame = clipStartSample + (int) frame;
+            CHECK (output.getSample (0, outputFrame) == doctest::Approx (1.0f).epsilon (0.001));
+
+            for (int delta : { -2, -1, 1, 2 })
+            {
+                CAPTURE (delta);
+                CHECK (std::abs (output.getSample (0, outputFrame + delta)) < 0.001f);
+            }
+        }
+    }
+
     /** Checks the source lines up with the timeline to the sample, not just roughly.
         Proxy-file clips play through a WaveNode, so any resampler latency it leaves
         uncompensated shows up as a phase offset against the same file playing
@@ -513,15 +546,8 @@ namespace wavenode_test_helpers
 
         // Impulses at the first frame and part way through. The clip starts on a block
         // boundary so the first frame checks the resampler has no history to flush
-        const choc::buffer::FrameCount impulseFrames[] = { 0, 1000 };
-        const auto numFileFrames = (choc::buffer::FrameCount) ts.sampleRate;
-        auto impulseBuffer = choc::buffer::createChannelArrayBuffer (1, numFileFrames,
-                                                                     [&] (auto, auto frame) -> float
-                                                                     {
-                                                                         return std::find (std::begin (impulseFrames), std::end (impulseFrames), frame)
-                                                                                  != std::end (impulseFrames) ? 1.0f : 0.0f;
-                                                                     });
-        auto impulseFile = writeToTemporaryFile<juce::WavAudioFormat> (impulseBuffer.getView(), ts.sampleRate);
+        const std::vector<choc::buffer::FrameCount> impulseFrames { 0, 1000 };
+        auto impulseFile = createImpulseFile (ts, impulseFrames);
         AudioFile impulseAudioFile (engine, impulseFile->getFile());
 
         tracktion::graph::PlayHead playHead;
@@ -545,24 +571,71 @@ namespace wavenode_test_helpers
                                         true);
 
         auto testContext = createTracktionTestContext (processState, std::move (node), ts, 1, 2.0);
-        auto& output = testContext->buffer;
 
         CAPTURE (ts.sampleRate);
         CAPTURE (ts.blockSize);
         CAPTURE (ts.randomiseBlockSizes);
 
-        for (auto frame : impulseFrames)
-        {
-            CAPTURE (frame);
-            const auto outputFrame = clipStartSample + (int) frame;
-            CHECK (output.getSample (0, outputFrame) == doctest::Approx (1.0f).epsilon (0.001));
+        expectImpulsesAt (testContext->buffer, clipStartSample, impulseFrames);
+    }
 
-            for (int delta : { -2, -1, 1, 2 })
-            {
-                CAPTURE (delta);
-                CHECK (std::abs (output.getSample (0, outputFrame + delta)) < 0.001f);
-            }
-        }
+    /** The same alignment check for SpeedRampWaveNode, which plays proxy clips that have
+        speed-ramp fades and resamples through its own copy of the same code.
+    */
+    static void runSpeedRampSampleAlignmentTests (graph::test_utilities::TestSetup ts)
+    {
+        using namespace tracktion::graph::test_utilities;
+        auto& engine = *Engine::getEngines()[0];
+
+        // A block straddling the clip start has its time clamped into the clip by
+        // editTimeToFileSample, so it resamples at a non-unity ratio and can't line up to
+        // the sample. Only the fixed block sizes start a block exactly on the clip
+        if (ts.randomiseBlockSizes)
+            return;
+
+        // The node ramps the gain up across the first block it plays, so the impulses have
+        // to sit past the largest block size to survive it
+        const std::vector<choc::buffer::FrameCount> impulseFrames { 2000, 3000 };
+        auto impulseFile = createImpulseFile (ts, impulseFrames);
+        AudioFile impulseAudioFile (engine, impulseFile->getFile());
+
+        tracktion::graph::PlayHead playHead;
+        tracktion::graph::PlayHeadState playHeadState (playHead);
+        ProcessState processState (playHeadState);
+        playHead.playSyncedToRange ({ 0, std::numeric_limits<int64_t>::max() });
+
+        const auto clipStartSample = (int) ts.blockSize * 10;
+        const auto clipStart = TimePosition::fromSamples (clipStartSample, ts.sampleRate);
+        const auto clipRange = TimeRange (clipStart, 1_td);
+
+        // The node requires one of its ramps to be non-empty, so fade the speed out over
+        // the last 200ms, well clear of the impulses
+        SpeedFadeDescription desc;
+        desc.inTimeRange = TimeRange (clipStart, TimeDuration());
+        desc.outTimeRange = TimeRange (clipRange.getEnd() - TimeDuration::fromSeconds (0.2),
+                                       TimeDuration::fromSeconds (0.2));
+        desc.fadeInType = AudioFadeCurve::linear;
+        desc.fadeOutType = AudioFadeCurve::linear;
+
+        auto node = makeNode<SpeedRampWaveNode> (impulseAudioFile,
+                                                 clipRange,
+                                                 TimeDuration(),
+                                                 TimeRange(),
+                                                 LiveClipLevel(),
+                                                 1.0,
+                                                 ChannelConfiguration::discreteChannels (impulseAudioFile.getNumChannels()),
+                                                 ChannelConfiguration::discreteChannels (1),
+                                                 processState,
+                                                 EditItemID(),
+                                                 true,
+                                                 desc);
+
+        auto testContext = createTracktionTestContext (processState, std::move (node), ts, 1, 2.0);
+
+        CAPTURE (ts.sampleRate);
+        CAPTURE (ts.blockSize);
+
+        expectImpulsesAt (testContext->buffer, clipStartSample, impulseFrames);
     }
 } // namespace wavenode_test_helpers
 
@@ -579,6 +652,7 @@ TEST_CASE ("WaveNode")
         runBasicTests<WaveNode> ("WaveNode", ts, false);
         runLoopedTimelineTests<WaveNode> ("WaveNode", ts);
         runSampleAlignmentTests<WaveNode> (ts);
+        runSpeedRampSampleAlignmentTests (ts);
     }
 
     MESSAGE ("WaveNodeRealTime");


### PR DESCRIPTION
## Summary
Clips playing from a proxy file were 2 samples late against the timeline. Any clip with Clip FX is forced onto a proxy, so e.g. a copy of a clip with Clip FX > Invert phase didn't null against the original (Tracktion/waveform_beta#933). Flattening or rendering such a clip baked the 2 extra samples into the result.

## Root cause
Proxy playback (and frozen tracks) go through `WaveNode`, which runs the file through a `juce::LagrangeInterpolator` even at a 1:1 ratio. That interpolator has a base latency of 2 input samples, which `WaveNode` never compensated for. The non-proxy path (`WaveNodeRealTime` / `LagrangeResamplerReader`) already compensates, which is why only proxy clips were affected.

A second, smaller bug showed up in the test: `WaveNode::editTimeToFileSample` rounded with `(int64_t) (x + 0.5)`, which truncates towards zero for negative times. A block straddling the clip start then read from one sample too late and used a non-unity ratio for that block, smearing the first samples of the clip.

## Fix (`tracktion_WaveNode.cpp`)
- Read `getBaseLatency()` extra frames per block and feed the resampler from that far in, so its output lines up with `fileStart`.
- After a reset (construction, or leaving the clip), the skipped frames prime the resampler's history first, so the very first output frame is exact too.
- `editTimeToFileSample` uses `std::floor (x + 0.5)` so negative times round like positive ones.

## Regression test
`runSampleAlignmentTests` in `tracktion_WaveNode.test.cpp`, run for both `WaveNode` and `WaveNodeRealTime` across all test setups. It plays a file with impulses at frame 0 and 1000, starting on a block boundary, and checks each lands on exactly the right timeline sample with silence either side.
- Before: 108 failures, all `WaveNode` (impulses at +2, and smeared in the random-block-size setups).
- After the latency fix only: 42 failures, all random-block-size setups (the rounding bug).
- After both: 4080/4080 pass. `WaveNodeRealTime` passed throughout.

Full TestRunner (Release, macOS): 345/345 test cases, 20835 assertions pass.

## Not changed (follow-ups)
- `SpeedRampWaveNode` (proxy clips with speed-ramp fades) is a copy of the same code and has both bugs. It's left alone here to keep this change small.
- Volume, Fade in/out, Step volume, Pitch shift and Plugin Clip FX render through `WaveNode` too, so their cached renders carry the same 2-sample shift. New renders are correct. Renders already cached keep the shift until something invalidates their hash. Invert, Normalise, Reverse and Make mono don't render through `WaveNode`, so the case reported in the issue is fixed without a re-render.
