### PR TITLE
Project: Moving a file in a folder-based project no longer re-saves Edits that do not reference it

### DIFF
--- a/modules/tracktion_engine/project/tracktion_FolderBasedProject.cpp
+++ b/modules/tracktion_engine/project/tracktion_FolderBasedProject.cpp
@@ -564,23 +564,34 @@ void FolderBasedProject::sourceFileMoved (const juce::File& oldFile, const juce:
     auto oldRef = ProjectItemRef::fromPath (oldFile.getRelativePathFrom (projectDir));
     auto newRef = ProjectItemRef::fromPath (newFile.getRelativePathFrom (projectDir), owner);
 
-    // Helper lambda to reassign refs in a single edit
+    // Helper lambda to reassign refs in a single edit, returning true if any were changed.
+    // Edits that don't reference the moved file mustn't be re-saved, as a save counts as a
+    // user save (e.g. it triggers the app's auto-backup)
     auto reassignInEdit = [&] (Edit& edit)
     {
+        bool anyReassigned = false;
+
         for (auto exportable : Exportable::addAllExportables (edit))
+        {
             for (auto& item : exportable->getReferencedItems())
+            {
                 if (item.itemRef == oldRef)
+                {
                     exportable->reassignReferencedItem (item, newRef, 0.0);
+                    anyReassigned = true;
+                }
+            }
+        }
+
+        return anyReassigned;
     };
 
     // 1. Update all currently open edits belonging to this project
     for (auto edit : owner.engine.getActiveEdits().getEdits())
     {
         if (edit != nullptr && owner.projectManager.getProject (*edit).get() == &owner)
-        {
-            reassignInEdit (*edit);
-            EditFileOperations (*edit).save (false, true, false);
-        }
+            if (reassignInEdit (*edit))
+                EditFileOperations (*edit).save (false, true, false);
     }
 
     // 2. Update closed edit files on disk
@@ -605,9 +616,8 @@ void FolderBasedProject::sourceFileMoved (const juce::File& oldFile, const juce:
                 {
                     auto ed = loadEditForExamining (owner.projectManager, item->getProjectItemRef());
 
-                    if (ed != nullptr)
+                    if (ed != nullptr && reassignInEdit (*ed))
                     {
-                        reassignInEdit (*ed);
                         EditFileOperations saveOps (*ed);
                         jassert (saveOps.getEditFile() == editFile);
                         saveOps.save (false, true, false);

--- a/modules/tracktion_engine/project/tracktion_Project.test.cpp
+++ b/modules/tracktion_engine/project/tracktion_Project.test.cpp
@@ -1717,6 +1717,56 @@ TEST_SUITE ("tracktion_engine")
         }
     }
 
+    TEST_CASE ("FolderBasedProject: renaming an Edit doesn't re-save Edits that don't reference it")
+    {
+        // Creating a project from a template renames each Edit. That used to re-save
+        // every closed Edit, which made the app auto-backup the brand new project.
+        auto& engine = *Engine::getEngines()[0];
+        auto& pm = engine.getProjectManager();
+
+        auto tempDir = juce::File::createTempFile ({});
+        auto projectPath = tempDir.getChildFile ("test_folder_project");
+        REQUIRE (projectPath.createDirectory());
+
+        {
+            ProjectManager::TempProject tp (pm, projectPath, false);
+            auto project = tp.project;
+            REQUIRE (project != nullptr);
+
+            auto editItem1 = project->createNewEdit();
+            auto editItem2 = project->createNewEdit();
+            REQUIRE (editItem1 != nullptr);
+            REQUIRE (editItem2 != nullptr);
+
+            for (auto item : { editItem1, editItem2 })
+            {
+                auto edit = createEmptyEdit (engine, item->getSourceFile());
+                edit->setProjectItemRef (item->getProjectItemRef());
+                edit->ensureNumberOfAudioTracks (1);
+                CHECK (test_utilities::saveEditSync (*edit));
+            }
+
+            project->save();
+
+            // Backdate the Edit files so any re-save shows up as a new modification time
+            const auto pastTime = juce::Time (2020, 0, 1, 12, 0);
+            const auto cutOff = juce::Time (2021, 0, 1, 12, 0);
+            CHECK (editItem1->getSourceFile().setLastModificationTime (pastTime));
+            CHECK (editItem2->getSourceFile().setLastModificationTime (pastTime));
+
+            editItem1->setName ("Renamed Edit", ProjectItem::SetNameMode::forceRenameSynchronous);
+
+            auto renamedFile = editItem1->getSourceFile();
+            CHECK (renamedFile.getFileNameWithoutExtension() == "Renamed Edit");
+            REQUIRE (renamedFile.existsAsFile());
+
+            CHECK (renamedFile.getLastModificationTime() < cutOff);
+            CHECK (editItem2->getSourceFile().getLastModificationTime() < cutOff);
+        }
+
+        tempDir.deleteRecursively (false);
+    }
+
     TEST_CASE ("ProjectID: basic operations")
     {
         // Default-constructed is invalid


### PR DESCRIPTION
## Summary
`FolderBasedProject::sourceFileMoved` force-saved **every** open and closed Edit in the project whenever any file moved, even when none of its references pointed at the moved file. It now saves an Edit only if at least one reference was actually reassigned.

## Why it matters
A save through `EditFileOperations::save` counts as a user save, so it calls `EngineBehaviour::editHasBeenSaved`. Waveform hooks that to its auto-backup.

Creating a project from a user template renames each extracted Edit ("<project name> Edit N"). The rename moves the Edit file, `sourceFileMoved` re-saved every Edit, and the app then wrote a backup into the brand new project. The Projects tab showed a backup before the user had done anything (Tracktion/waveform_beta#1248).

A second effect: moving any file in a project also force-saved the user's unsaved changes in every open Edit of that project. That stops too.

Edits that do reference the moved file are still updated and saved exactly as before.

## Regression test
`FolderBasedProject: renaming an Edit doesn't re-save Edits that don't reference it` in `tracktion_Project.test.cpp`:
- creates a folder-based project with two saved Edits and backdates both files to 2020
- renames one Edit with `SetNameMode::forceRenameSynchronous`, the call the template flow makes
- checks both files keep their old modification time, i.e. neither was re-saved

It fails before the change (both Edits re-saved) and passes after. Full TestRunner suite: 268/268 test cases, 9380 assertions, all passing. The existing `sourceFileMoved` tests still pass, which covers the case where an Edit does reference the moved file.

## Notes
The app-side submodule bump is Tracktion/waveform#107.
